### PR TITLE
Add no-assert-rejects rule and cover node:assert plus strict imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ ESLint rules for [Node.js assert module](https://nodejs.org/docs/latest/api/asse
 
 <!-- begin auto-generated rules list -->
 
-| Name                                         | Description                               |
-| :------------------------------------------- | :---------------------------------------- |
-| [import-strict](docs/rules/import-strict.md) | Enforce the usage of 'node:assert/strict' |
+| Name                                                 | Description                               |
+| :--------------------------------------------------- | :---------------------------------------- |
+| [import-strict](docs/rules/import-strict.md)         | Enforce the usage of 'node:assert/strict' |
+| [no-assert-rejects](docs/rules/no-assert-rejects.md) | Disallow the usage of 'assert.rejects'    |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/no-assert-rejects.md
+++ b/docs/rules/no-assert-rejects.md
@@ -1,0 +1,27 @@
+# Disallow the usage of 'assert.rejects' (`node-assert/no-assert-rejects`)
+
+<!-- end auto-generated rule header -->
+
+This rule reports calls to `assert.rejects`.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+await assert.rejects(async () => {
+  throw new Error("boom");
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+assert.throws(() => {
+  throw new Error("boom");
+});
+```

--- a/source/all-rules.ts
+++ b/source/all-rules.ts
@@ -1,8 +1,10 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 import { importStrictRule } from "./rules/import-strict.js";
+import { noAssertRejectsRule } from "./rules/no-assert-rejects.js";
 
 const allRules: Record<string, TSESLint.RuleModule<string, unknown[]>> = {
-	"import-strict": importStrictRule
+	"import-strict": importStrictRule,
+	"no-assert-rejects": noAssertRejectsRule
 };
 
 export default {

--- a/source/rules/no-assert-rejects.ts
+++ b/source/rules/no-assert-rejects.ts
@@ -1,0 +1,93 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+
+function ruleDocumentationUrl(name: string): string {
+	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
+}
+
+const createRule = ESLintUtils.RuleCreator(ruleDocumentationUrl);
+
+function isAssertRejectsCall(node: Readonly<TSESTree.CallExpression>): boolean {
+	if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+		return false;
+	}
+
+	const memberExpressionNode = node.callee;
+
+	if (memberExpressionNode.property.type === AST_NODE_TYPES.Identifier) {
+		return memberExpressionNode.property.name === "rejects";
+	}
+
+	if (memberExpressionNode.property.type === AST_NODE_TYPES.Literal) {
+		return memberExpressionNode.property.value === "rejects";
+	}
+
+	return false;
+}
+
+export const noAssertRejectsRule = createRule({
+	name: "no-assert-rejects",
+	meta: {
+		docs: {
+			description: "Disallow the usage of 'assert.rejects'"
+		},
+		messages: {
+			"no-assert-rejects": "Do not use 'assert.rejects'"
+		},
+		type: "suggestion",
+		schema: []
+	},
+	defaultOptions: [],
+
+	create(context) {
+		const importedAssertModuleIdentifiers = new Set<string>();
+
+		function isAssertModuleImport(importDeclarationNode: Readonly<TSESTree.ImportDeclaration>): boolean {
+			return (
+				importDeclarationNode.source.value === "node:assert" ||
+				importDeclarationNode.source.value === "node:assert/strict"
+			);
+		}
+
+		function isObjectImportedFromAssertModule(
+			importSpecifierNode: Readonly<TSESTree.ImportClause>
+		): importSpecifierNode is TSESTree.ImportDefaultSpecifier | TSESTree.ImportNamespaceSpecifier {
+			return (
+				importSpecifierNode.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
+				importSpecifierNode.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+			);
+		}
+
+		return {
+			ImportDeclaration(node) {
+				if (!isAssertModuleImport(node)) {
+					return;
+				}
+
+				for (const importSpecifier of node.specifiers) {
+					if (isObjectImportedFromAssertModule(importSpecifier)) {
+						importedAssertModuleIdentifiers.add(importSpecifier.local.name);
+					}
+				}
+			},
+
+			CallExpression(node) {
+				if (!isAssertRejectsCall(node)) {
+					return;
+				}
+
+				if (
+					node.callee.type !== AST_NODE_TYPES.MemberExpression ||
+					node.callee.object.type !== AST_NODE_TYPES.Identifier ||
+					!importedAssertModuleIdentifiers.has(node.callee.object.name)
+				) {
+					return;
+				}
+
+				context.report({
+					messageId: "no-assert-rejects",
+					node
+				});
+			}
+		};
+	}
+});

--- a/test/rules/no-assert-rejects.test.ts
+++ b/test/rules/no-assert-rejects.test.ts
@@ -1,0 +1,32 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { noAssertRejectsRule } from "../../source/rules/no-assert-rejects.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-assert-rejects", noAssertRejectsRule, {
+	valid: [
+		"import assert from 'node:assert/strict'; assert.throws(() => new Error('x'));",
+		"import assert from 'node:assert/strict'; assert.doesNotReject(async () => Promise.resolve());",
+		"import assertionLibrary from 'node:assert/strict'; assertionLibrary.throws(() => new Error('x'));",
+		"import assert from 'node:assert'; assert.throws(() => new Error('x'));",
+		"import assertionLibrary from 'node:assert'; assertionLibrary.throws(() => new Error('x'));"
+	],
+	invalid: [
+		{
+			code: "import assert from 'node:assert/strict'; assert.rejects(async () => Promise.reject(new Error('x')));",
+			errors: [{ messageId: "no-assert-rejects" }]
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert['rejects'](async () => Promise.reject(new Error('x')));",
+			errors: [{ messageId: "no-assert-rejects" }]
+		},
+		{
+			code: "import assert from 'node:assert'; assert.rejects(async () => Promise.reject(new Error('x')));",
+			errors: [{ messageId: "no-assert-rejects" }]
+		},
+		{
+			code: "import assertionLibrary from 'node:assert'; assertionLibrary.rejects(async () => Promise.reject(new Error('x')));",
+			errors: [{ messageId: "no-assert-rejects" }]
+		}
+	]
+});


### PR DESCRIPTION
Prevent asynchronous assertion patterns that rely on assert.rejects, while still allowing teams to choose either node:assert or node:assert/strict as their import source.