### PR TITLE
Add node-assert/no-constant-actual rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ ESLint rules for [Node.js assert module](https://nodejs.org/docs/latest/api/asse
 
 <!-- begin auto-generated rules list -->
 
-| Name                                         | Description                               |
-| :------------------------------------------- | :---------------------------------------- |
-| [import-strict](docs/rules/import-strict.md) | Enforce the usage of 'node:assert/strict' |
+🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
+
+| Name                                                   | Description                                                                       | 🔧 |
+| :----------------------------------------------------- | :-------------------------------------------------------------------------------- | :- |
+| [import-strict](docs/rules/import-strict.md)           | Enforce the usage of 'node:assert/strict'                                         |    |
+| [no-constant-actual](docs/rules/no-constant-actual.md) | Disallow passing a constant value as the first argument to Node.js assert methods | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/no-constant-actual.md
+++ b/docs/rules/no-constant-actual.md
@@ -1,0 +1,77 @@
+# Disallow passing a constant value as the first argument to Node.js assert methods (`node-assert/no-constant-actual`)
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+Node.js assert methods such as `strictEqual` accept the arguments in the order `actual, expected`. When the order is reversed, assertion failures are difficult to interpret because the diff is reported the wrong way around. Likewise, asserting against a hard-coded constant value (or comparing two constants) produces a deterministic test that has no meaningful effect.
+
+This rule reports calls to the covered `node:assert` and `node:assert/strict` methods (also matched via the bare `assert` and `assert/strict` specifiers) whose first argument is a constant value (a literal, a constant template literal, an array or object built only from constants, `undefined`, `NaN`, `Infinity`, or a unary expression over a constant). It does not report calls where both arguments are non-constant (ambiguous, like `foo(), bar()`).
+
+### Covered methods
+
+Two-argument methods (`actual, expected[, message]`):
+
+- `equal`, `strictEqual`, `notEqual`, `notStrictEqual`
+- `deepEqual`, `deepStrictEqual`, `notDeepEqual`, `notDeepStrictEqual`
+- `partialDeepStrictEqual`
+- `match`, `doesNotMatch`
+- `throws`, `doesNotThrow`, `rejects`, `doesNotReject`
+
+Single-argument methods (`actual`):
+
+- `ifError`
+
+### Messages
+
+- `no-constant-actual` (autofix available): the first argument is constant and the second is not. Almost certainly a swap.
+- `constant-comparison` (no autofix): both arguments are constant. The test compares two known values and is likely meaningless.
+- `constant-actual` (no autofix): a single-argument method like `ifError` was called with a constant value, so the assertion is deterministic.
+
+The following patterns are considered warnings:
+
+```js
+import assert from "node:assert/strict";
+
+assert.strictEqual(42, actual);
+assert.deepStrictEqual({ ok: true }, result);
+assert.notStrictEqual(null, value);
+assert.equal("foo", result);
+assert.throws({ message: "boom" }, fn);
+assert.match(/pattern/, value);
+assert.ifError("not an error");
+```
+
+These patterns would not be considered warnings:
+
+```js
+import assert from "node:assert/strict";
+
+assert.strictEqual(actual, 42);
+assert.deepStrictEqual(result, { ok: true });
+assert.notStrictEqual(value, null);
+assert.throws(fn, { message: "boom" });
+assert.match(value, /pattern/);
+assert.ifError(err);
+```
+
+### Autofix
+
+For two-argument methods, the autofix swaps the two arguments. To avoid losing context, the autofix is skipped when comments appear between the arguments.
+
+For `match` and `doesNotMatch` the two arguments have different types (`string` and `RegExp`). The autofix is still applied because in the typical mistake case the constant first argument is the regex, and swapping yields the correct shape; review fixes carefully if your code ends up in the rare opposite arrangement.
+
+### Recognized usage patterns
+
+The rule resolves common indirections on top of plain `assert.method(...)` calls:
+
+- Imports from `node:assert`, `node:assert/strict`, `assert`, and `assert/strict`.
+- Aliased named imports (`import { strictEqual as foo } from 'node:assert/strict'; foo(...)`).
+- Computed member access with a string literal (`assert['strictEqual'](...)`), a constant template literal (`` assert[`strictEqual`](...) ``), or a `const`-declared string (`const key = 'strictEqual'; assert[key](...)`).
+- Aliasing the namespace (`const a = assert; a.strictEqual(...)`), including multi-hop chains (`const a = assert; const b = a; b.strictEqual(...)`).
+- Destructuring from the namespace (`const { strictEqual } = assert; strictEqual(...)`), including renames (`const { strictEqual: foo } = assert; foo(...)`).
+- Re-binding a named import (`const eq = strictEqual; eq(...)`).
+
+`let`-declared aliases are intentionally not tracked because the binding could be reassigned. CommonJS `require` is not tracked.

--- a/source/all-rules.ts
+++ b/source/all-rules.ts
@@ -1,8 +1,10 @@
 import type { TSESLint } from "@typescript-eslint/utils";
 import { importStrictRule } from "./rules/import-strict.js";
+import { noConstantActualRule } from "./rules/no-constant-actual.js";
 
 const allRules: Record<string, TSESLint.RuleModule<string, unknown[]>> = {
-	"import-strict": importStrictRule
+	"import-strict": importStrictRule,
+	"no-constant-actual": noConstantActualRule
 };
 
 export default {

--- a/source/ast/is-constant.ts
+++ b/source/ast/is-constant.ts
@@ -1,0 +1,36 @@
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/utils";
+
+const CONSTANT_GLOBALS: ReadonlySet<string> = new Set(["undefined", "NaN", "Infinity"]);
+
+function isConstantLiteralLike(node: Readonly<TSESTree.Node>): boolean {
+	if (node.type === AST_NODE_TYPES.Literal) {
+		return true;
+	}
+	if (node.type === AST_NODE_TYPES.TemplateLiteral) {
+		return node.expressions.length === 0;
+	}
+	if (node.type === AST_NODE_TYPES.Identifier) {
+		return CONSTANT_GLOBALS.has(node.name);
+	}
+	return false;
+}
+
+export function isConstant(node: Readonly<TSESTree.Node>): boolean {
+	if (isConstantLiteralLike(node)) {
+		return true;
+	}
+	if (node.type === AST_NODE_TYPES.UnaryExpression) {
+		return isConstant(node.argument);
+	}
+	if (node.type === AST_NODE_TYPES.ArrayExpression) {
+		return node.elements.every((element) => {
+			return element !== null && element.type !== AST_NODE_TYPES.SpreadElement && isConstant(element);
+		});
+	}
+	if (node.type === AST_NODE_TYPES.ObjectExpression) {
+		return node.properties.every((property) => {
+			return property.type === AST_NODE_TYPES.Property && !property.computed && isConstant(property.value);
+		});
+	}
+	return false;
+}

--- a/source/node-assert/method-tracker.ts
+++ b/source/node-assert/method-tracker.ts
@@ -1,0 +1,146 @@
+import { AST_NODE_TYPES, ASTUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { isAssertModuleSpecifier } from "./modules.js";
+
+export type AssertBindingTrackerOptions = {
+	readonly isAssertMethod: (name: string) => boolean;
+};
+
+export type AssertBindingTracker = {
+	readonly processImport: (node: Readonly<TSESTree.ImportDeclaration>) => void;
+	readonly processVariableDeclaration: (node: Readonly<TSESTree.VariableDeclaration>) => void;
+	readonly resolveMethodCall: (
+		callee: Readonly<TSESTree.Expression>,
+		// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to ESLint scope helpers that require the mutable Scope shape
+		scope: TSESLint.Scope.Scope
+	) => string | undefined;
+};
+
+type TrackerState = {
+	readonly namespaces: Set<string>;
+	readonly methodBindings: Map<string, string>;
+	readonly isAssertMethod: (name: string) => boolean;
+};
+
+function getDestructuredMethod(
+	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
+	isAssertMethod: (name: string) => boolean
+): { readonly localName: string; readonly methodName: string } | undefined {
+	if (property.type !== AST_NODE_TYPES.Property || property.computed) {
+		return undefined;
+	}
+	if (property.key.type !== AST_NODE_TYPES.Identifier || !isAssertMethod(property.key.name)) {
+		return undefined;
+	}
+	if (property.value.type !== AST_NODE_TYPES.Identifier) {
+		return undefined;
+	}
+	return { localName: property.value.name, methodName: property.key.name };
+}
+
+function addDestructured(state: TrackerState, pattern: Readonly<TSESTree.ObjectPattern>): void {
+	for (const property of pattern.properties) {
+		const destructured = getDestructuredMethod(property, state.isAssertMethod);
+		if (destructured !== undefined) {
+			state.methodBindings.set(destructured.localName, destructured.methodName);
+		}
+	}
+}
+
+function addImportSpecifier(state: TrackerState, specifier: Readonly<TSESTree.ImportClause>): void {
+	if (
+		specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
+		specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier
+	) {
+		state.namespaces.add(specifier.local.name);
+		return;
+	}
+	if (specifier.imported.type !== AST_NODE_TYPES.Identifier) {
+		return;
+	}
+	if (state.isAssertMethod(specifier.imported.name)) {
+		state.methodBindings.set(specifier.local.name, specifier.imported.name);
+	}
+}
+
+function addFromNamespace(state: TrackerState, id: Readonly<TSESTree.Node>): void {
+	if (id.type === AST_NODE_TYPES.Identifier) {
+		state.namespaces.add(id.name);
+		return;
+	}
+	if (id.type === AST_NODE_TYPES.ObjectPattern) {
+		addDestructured(state, id);
+	}
+}
+
+function addDeclarator(state: TrackerState, declarator: Readonly<TSESTree.VariableDeclarator>): void {
+	if (declarator.init?.type !== AST_NODE_TYPES.Identifier) {
+		return;
+	}
+	const sourceName = declarator.init.name;
+	if (state.namespaces.has(sourceName)) {
+		addFromNamespace(state, declarator.id);
+		return;
+	}
+	const aliased = state.methodBindings.get(sourceName);
+	if (aliased !== undefined && declarator.id.type === AST_NODE_TYPES.Identifier) {
+		state.methodBindings.set(declarator.id.name, aliased);
+	}
+}
+
+function resolveMemberMethod(
+	state: TrackerState,
+	callee: Readonly<TSESTree.MemberExpression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- ESLint's getPropertyName needs the mutable Scope shape
+	scope: TSESLint.Scope.Scope
+): string | undefined {
+	if (callee.object.type !== AST_NODE_TYPES.Identifier || !state.namespaces.has(callee.object.name)) {
+		return undefined;
+	}
+	const propertyName = ASTUtils.getPropertyName(callee, scope);
+	if (propertyName === null || !state.isAssertMethod(propertyName)) {
+		return undefined;
+	}
+	return propertyName;
+}
+
+export function createAssertBindingTracker(options: AssertBindingTrackerOptions): AssertBindingTracker {
+	const state: TrackerState = {
+		namespaces: new Set<string>(),
+		methodBindings: new Map<string, string>(),
+		isAssertMethod: options.isAssertMethod
+	};
+
+	function processImport(node: Readonly<TSESTree.ImportDeclaration>): void {
+		if (!isAssertModuleSpecifier(node.source.value)) {
+			return;
+		}
+		for (const specifier of node.specifiers) {
+			addImportSpecifier(state, specifier);
+		}
+	}
+
+	function processVariableDeclaration(node: Readonly<TSESTree.VariableDeclaration>): void {
+		if (node.kind !== "const") {
+			return;
+		}
+		for (const declarator of node.declarations) {
+			addDeclarator(state, declarator);
+		}
+	}
+
+	function resolveMethodCall(
+		callee: Readonly<TSESTree.Expression>,
+		// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to ESLint scope helpers
+		scope: TSESLint.Scope.Scope
+	): string | undefined {
+		if (callee.type === AST_NODE_TYPES.MemberExpression) {
+			return resolveMemberMethod(state, callee, scope);
+		}
+		if (callee.type === AST_NODE_TYPES.Identifier) {
+			return state.methodBindings.get(callee.name);
+		}
+		return undefined;
+	}
+
+	return { processImport, processVariableDeclaration, resolveMethodCall };
+}

--- a/source/node-assert/modules.ts
+++ b/source/node-assert/modules.ts
@@ -1,0 +1,10 @@
+export const ASSERT_MODULES: ReadonlySet<string> = new Set([
+	"node:assert",
+	"node:assert/strict",
+	"assert",
+	"assert/strict"
+]);
+
+export function isAssertModuleSpecifier(value: unknown): boolean {
+	return typeof value === "string" && ASSERT_MODULES.has(value);
+}

--- a/source/rules/no-constant-actual.ts
+++ b/source/rules/no-constant-actual.ts
@@ -1,0 +1,158 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { isConstant } from "../ast/is-constant.js";
+import { createAssertBindingTracker } from "../node-assert/method-tracker.js";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
+});
+
+const TWO_ARG_METHODS: ReadonlySet<string> = new Set([
+	"equal",
+	"strictEqual",
+	"notEqual",
+	"notStrictEqual",
+	"deepEqual",
+	"deepStrictEqual",
+	"notDeepEqual",
+	"notDeepStrictEqual",
+	"partialDeepStrictEqual",
+	"match",
+	"doesNotMatch",
+	"throws",
+	"doesNotThrow",
+	"rejects",
+	"doesNotReject"
+]);
+
+const ONE_ARG_METHODS: ReadonlySet<string> = new Set(["ifError"]);
+
+function isAssertMethodName(name: string): boolean {
+	return TWO_ARG_METHODS.has(name) || ONE_ARG_METHODS.has(name);
+}
+
+type EqualityArguments = {
+	readonly actualArg: TSESTree.Expression;
+	readonly expectedArg: TSESTree.Expression;
+};
+
+function getEqualityArguments(args: readonly TSESTree.CallExpressionArgument[]): EqualityArguments | undefined {
+	const [actualArg, expectedArg] = args;
+	if (actualArg === undefined || expectedArg === undefined) {
+		return undefined;
+	}
+	if (actualArg.type === AST_NODE_TYPES.SpreadElement || expectedArg.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return { actualArg, expectedArg };
+}
+
+function getSingleArgument(
+	args: readonly TSESTree.CallExpressionArgument[]
+): Readonly<TSESTree.Expression> | undefined {
+	const [arg] = args;
+	if (arg === undefined || arg.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return arg;
+}
+
+function hasCommentsBetween(
+	callNode: Readonly<TSESTree.CallExpression>,
+	actualArg: Readonly<TSESTree.Expression>,
+	expectedArg: Readonly<TSESTree.Expression>,
+	sourceCode: Readonly<TSESLint.SourceCode>
+): boolean {
+	return sourceCode.getCommentsInside(callNode).some((comment) => {
+		return comment.range[0] >= actualArg.range[0] && comment.range[1] <= expectedArg.range[1];
+	});
+}
+
+function buildSwapFix(
+	actualArg: Readonly<TSESTree.Expression>,
+	expectedArg: Readonly<TSESTree.Expression>,
+	sourceCode: Readonly<TSESLint.SourceCode>
+): TSESLint.ReportFixFunction {
+	return (fixer) => {
+		const actualText = sourceCode.getText(actualArg);
+		const expectedText = sourceCode.getText(expectedArg);
+		return [fixer.replaceText(actualArg, expectedText), fixer.replaceText(expectedArg, actualText)];
+	};
+}
+
+export const noConstantActualRule = createRule({
+	name: "no-constant-actual",
+	meta: {
+		docs: {
+			description: "Disallow passing a constant value as the first argument to Node.js assert methods"
+		},
+		messages: {
+			"no-constant-actual":
+				"The first argument should be the actual value; move the constant to the second argument",
+			"constant-comparison": "Both arguments are constant; one of these should be the actual value being tested",
+			"constant-actual":
+				"The actual value passed to this assertion is a constant; this assertion has no meaningful effect"
+		},
+		type: "problem",
+		fixable: "code",
+		schema: []
+	},
+	defaultOptions: [],
+
+	create(context) {
+		const tracker = createAssertBindingTracker({ isAssertMethod: isAssertMethodName });
+		const { sourceCode } = context;
+
+		function reportSwap(
+			callNode: Readonly<TSESTree.CallExpression>,
+			actualArg: Readonly<TSESTree.Expression>,
+			expectedArg: Readonly<TSESTree.Expression>
+		): void {
+			const canFix = !hasCommentsBetween(callNode, actualArg, expectedArg, sourceCode);
+			context.report({
+				messageId: "no-constant-actual",
+				node: callNode,
+				fix: canFix ? buildSwapFix(actualArg, expectedArg, sourceCode) : null
+			});
+		}
+
+		function handleTwoArgCall(node: Readonly<TSESTree.CallExpression>): void {
+			const equality = getEqualityArguments(node.arguments);
+			if (equality === undefined) {
+				return;
+			}
+			const { actualArg, expectedArg } = equality;
+			if (!isConstant(actualArg)) {
+				return;
+			}
+			if (isConstant(expectedArg)) {
+				context.report({ messageId: "constant-comparison", node });
+				return;
+			}
+			reportSwap(node, actualArg, expectedArg);
+		}
+
+		function handleOneArgCall(node: Readonly<TSESTree.CallExpression>): void {
+			const arg = getSingleArgument(node.arguments);
+			if (arg === undefined || !isConstant(arg)) {
+				return;
+			}
+			context.report({ messageId: "constant-actual", node });
+		}
+
+		return {
+			ImportDeclaration: tracker.processImport,
+			VariableDeclaration: tracker.processVariableDeclaration,
+			CallExpression(node) {
+				const methodName = tracker.resolveMethodCall(node.callee, sourceCode.getScope(node));
+				if (methodName === undefined) {
+					return;
+				}
+				if (ONE_ARG_METHODS.has(methodName)) {
+					handleOneArgCall(node);
+					return;
+				}
+				handleTwoArgCall(node);
+			}
+		};
+	}
+});

--- a/test/ast/is-constant.test.ts
+++ b/test/ast/is-constant.test.ts
@@ -1,0 +1,96 @@
+import * as assert from "node:assert/strict";
+import { suite, test } from "mocha";
+import type { Rule } from "eslint";
+import type { TSESTree } from "@typescript-eslint/utils";
+import { isConstant } from "../../source/ast/is-constant.js";
+import { expectNoLintFailure, runProbeRule } from "../helpers/linter-runner.js";
+
+function evaluate(expressionSource: string): boolean {
+	const observations: boolean[] = [];
+	const code = `(${expressionSource});`;
+	const probeRule: Rule.RuleModule = {
+		create() {
+			return {
+				ExpressionStatement(node) {
+					const { expression } = node as unknown as TSESTree.ExpressionStatement;
+					observations.push(isConstant(expression));
+				}
+			};
+		}
+	};
+	const messages = runProbeRule({ code, rule: probeRule });
+	expectNoLintFailure(messages);
+	const [first] = observations;
+	if (first === undefined) {
+		throw new Error(`No expression encountered for source: ${expressionSource}`);
+	}
+	return first;
+}
+
+const CONSTANT_SAMPLES: readonly string[] = [
+	"42",
+	"-1",
+	"3.14",
+	"'foo'",
+	"`hello`",
+	"true",
+	"false",
+	"null",
+	"42n",
+	"/foo/",
+	"undefined",
+	"NaN",
+	"Infinity",
+	"-Infinity",
+	"!true",
+	"~0",
+	"void 0",
+	"typeof 'foo'",
+	"[]",
+	"[1, 2, 3]",
+	"[[1], [2]]",
+	"{}",
+	"{ a: 1 }",
+	"{ a: { b: 1 } }",
+	"{ 'string-key': 1 }"
+];
+
+// eslint-disable-next-line no-template-curly-in-string -- intentional template expression in fixture source
+const TEMPLATE_WITH_EXPRESSION = "`hi ${name}`";
+
+const NON_CONSTANT_SAMPLES: readonly string[] = [
+	"foo",
+	"foo()",
+	"obj.prop",
+	"new Date()",
+	"new Date(42)",
+	"Symbol('x')",
+	TEMPLATE_WITH_EXPRESSION,
+	"typeof actualThing",
+	"a + b",
+	"a || b",
+	"a ? b : c",
+	"async () => 1",
+	"[foo]",
+	"[1, foo]",
+	"[...rest]",
+	"{ a: foo }",
+	"{ [k]: 1 }",
+	"{ ...other }",
+	"{ method() {} }",
+	"{ get x() { return 1; } }"
+];
+
+suite("isConstant()", function () {
+	test("returns true for every constant sample", function () {
+		for (const sample of CONSTANT_SAMPLES) {
+			assert.strictEqual(evaluate(sample), true, `expected isConstant(${sample}) to be true`);
+		}
+	});
+
+	test("returns false for every non-constant sample", function () {
+		for (const sample of NON_CONSTANT_SAMPLES) {
+			assert.strictEqual(evaluate(sample), false, `expected isConstant(${sample}) to be false`);
+		}
+	});
+});

--- a/test/helpers/linter-runner.ts
+++ b/test/helpers/linter-runner.ts
@@ -1,0 +1,40 @@
+import { Linter, type Rule } from "eslint";
+
+type LinterRule = Readonly<Rule.RuleModule>;
+
+export type RunRuleOptions = {
+	readonly code: string;
+	readonly rule: LinterRule;
+	readonly sourceType?: "module" | "script";
+};
+
+export function runProbeRule(options: RunRuleOptions): readonly Linter.LintMessage[] {
+	const linter = new Linter();
+	const sourceType = options.sourceType ?? "module";
+	const messages = linter.verify(options.code, {
+		plugins: {
+			"probe-plugin": {
+				rules: { probe: options.rule }
+			}
+		},
+		languageOptions: { ecmaVersion: 2024, sourceType },
+		rules: { "probe-plugin/probe": "error" }
+	});
+	return messages;
+}
+
+const SEVERITY_ERROR = 2;
+
+export function expectNoLintFailure(messages: readonly Linter.LintMessage[]): void {
+	const fatal = messages.filter((message) => {
+		return message.fatal === true || message.severity === SEVERITY_ERROR;
+	});
+	if (fatal.length > 0) {
+		const text = fatal
+			.map((message) => {
+				return `${message.ruleId ?? "<parser>"}: ${message.message}`;
+			})
+			.join("\n");
+		throw new Error(`Probe rule reported failures:\n${text}`);
+	}
+}

--- a/test/node-assert/method-tracker.test.ts
+++ b/test/node-assert/method-tracker.test.ts
@@ -1,0 +1,175 @@
+import * as assert from "node:assert/strict";
+import { suite, test } from "mocha";
+import type { Rule } from "eslint";
+import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { createAssertBindingTracker } from "../../source/node-assert/method-tracker.js";
+import { expectNoLintFailure, runProbeRule } from "../helpers/linter-runner.js";
+
+const ASSERT_METHODS: ReadonlySet<string> = new Set(["strictEqual", "deepStrictEqual", "ifError"]);
+
+function isAssertMethod(name: string): boolean {
+	return ASSERT_METHODS.has(name);
+}
+
+type ResolvedCall = {
+	readonly calleeText: string;
+	readonly resolvedMethod: string | undefined;
+};
+
+function resolveCallsIn(code: string): readonly ResolvedCall[] {
+	const calls: ResolvedCall[] = [];
+	const probeRule: Rule.RuleModule = {
+		create(context) {
+			const tracker = createAssertBindingTracker({ isAssertMethod });
+			return {
+				ImportDeclaration(node) {
+					tracker.processImport(node as unknown as TSESTree.ImportDeclaration);
+				},
+				VariableDeclaration(node) {
+					tracker.processVariableDeclaration(node as unknown as TSESTree.VariableDeclaration);
+				},
+				CallExpression(node) {
+					const calleeNode = node.callee;
+					const scope = context.sourceCode.getScope(node) as unknown as TSESLint.Scope.Scope;
+					const resolved = tracker.resolveMethodCall(calleeNode as unknown as TSESTree.Expression, scope);
+					calls.push({
+						calleeText: context.sourceCode.getText(calleeNode),
+						resolvedMethod: resolved
+					});
+				}
+			};
+		}
+	};
+	const messages = runProbeRule({ code, rule: probeRule });
+	expectNoLintFailure(messages);
+	return calls;
+}
+
+suite("createAssertBindingTracker()", function () {
+	suite("default and namespace imports", function () {
+		test("resolves member calls on a default import", function () {
+			const calls = resolveCallsIn("import assert from 'node:assert/strict'; assert.strictEqual(1, 2);");
+			assert.strictEqual(calls.length, 1);
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+		});
+
+		test("resolves member calls on a namespace import", function () {
+			const calls = resolveCallsIn(
+				"import * as assert from 'node:assert/strict'; assert.deepStrictEqual({}, {});"
+			);
+			assert.strictEqual(calls[0]?.resolvedMethod, "deepStrictEqual");
+		});
+
+		test("returns undefined for methods outside the predicate", function () {
+			const calls = resolveCallsIn("import assert from 'node:assert/strict'; assert.ok(value);");
+			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
+		});
+	});
+
+	suite("named imports", function () {
+		test("resolves direct named imports", function () {
+			const calls = resolveCallsIn("import { strictEqual } from 'node:assert/strict'; strictEqual(1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+		});
+
+		test("resolves aliased named imports", function () {
+			const calls = resolveCallsIn("import { strictEqual as eq } from 'node:assert/strict'; eq(1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+		});
+	});
+
+	suite("module specifiers", function () {
+		test("matches bare specifiers without the node: protocol", function () {
+			const calls = resolveCallsIn("import assert from 'assert/strict'; assert.strictEqual(1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+		});
+
+		test("ignores imports from unrelated modules", function () {
+			const calls = resolveCallsIn("import { strictEqual } from 'somewhere-else'; strictEqual(1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
+		});
+	});
+
+	suite("computed access", function () {
+		test("resolves a string literal property", function () {
+			const calls = resolveCallsIn("import assert from 'node:assert/strict'; assert['strictEqual'](1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+		});
+
+		test("resolves a const-bound string property via getStringIfConstant", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; const key = 'strictEqual'; assert[key](1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("returns undefined when the property cannot be resolved", function () {
+			const calls = resolveCallsIn("import assert from 'node:assert/strict'; assert[someKey](1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
+		});
+	});
+
+	suite("const-declared aliases", function () {
+		test("tracks namespace aliases", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; const a = assert; a.strictEqual(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("tracks multi-hop namespace aliases", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("tracks destructured method bindings", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("tracks renamed destructured method bindings", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; const { strictEqual: foo } = assert; foo(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("tracks re-bindings of named imports", function () {
+			const calls = resolveCallsIn(
+				"import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+
+		test("ignores let-declared aliases", function () {
+			const calls = resolveCallsIn(
+				"import assert from 'node:assert/strict'; let a = assert; a.strictEqual(1, 2);"
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, undefined);
+		});
+
+		test("ignores destructuring of methods outside the predicate", function () {
+			const calls = resolveCallsIn("import assert from 'node:assert/strict'; const { ok } = assert; ok(value);");
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, undefined);
+		});
+	});
+
+	suite("non-tracked patterns", function () {
+		test("does not match member calls on unrelated objects", function () {
+			const calls = resolveCallsIn("const other = { strictEqual: () => {} }; other.strictEqual(1, 2);");
+			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
+		});
+
+		test("does not match calls before the import is processed", function () {
+			const calls = resolveCallsIn(
+				"someOtherCall(1, 2); import assert from 'node:assert/strict'; assert.strictEqual(1, 2);"
+			);
+			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+	});
+});

--- a/test/node-assert/modules.test.ts
+++ b/test/node-assert/modules.test.ts
@@ -1,0 +1,37 @@
+import * as assert from "node:assert/strict";
+import { suite, test } from "mocha";
+import { ASSERT_MODULES, isAssertModuleSpecifier } from "../../source/node-assert/modules.js";
+
+const NUMERIC_NON_STRING = 42;
+
+const SUPPORTED_SPECIFIERS: readonly string[] = ["node:assert", "node:assert/strict", "assert", "assert/strict"];
+
+const REJECTED_SPECIFIERS: readonly string[] = ["node:fs", "chai", "node:assert/something-else", "./assert", ""];
+
+suite("node-assert/modules", function () {
+	test("ASSERT_MODULES contains exactly the supported specifiers", function () {
+		assert.strictEqual(ASSERT_MODULES.size, SUPPORTED_SPECIFIERS.length);
+		for (const specifier of SUPPORTED_SPECIFIERS) {
+			assert.ok(ASSERT_MODULES.has(specifier), `expected ASSERT_MODULES to contain ${specifier}`);
+		}
+	});
+
+	test("isAssertModuleSpecifier() returns true for every supported specifier", function () {
+		for (const specifier of SUPPORTED_SPECIFIERS) {
+			assert.strictEqual(isAssertModuleSpecifier(specifier), true, `expected ${specifier} to be accepted`);
+		}
+	});
+
+	test("isAssertModuleSpecifier() returns false for unrelated specifiers", function () {
+		for (const specifier of REJECTED_SPECIFIERS) {
+			assert.strictEqual(isAssertModuleSpecifier(specifier), false, `expected ${specifier} to be rejected`);
+		}
+	});
+
+	test("isAssertModuleSpecifier() returns false for non-string values", function () {
+		assert.strictEqual(isAssertModuleSpecifier(NUMERIC_NON_STRING), false);
+		assert.strictEqual(isAssertModuleSpecifier(null), false);
+		assert.strictEqual(isAssertModuleSpecifier(undefined), false);
+		assert.strictEqual(isAssertModuleSpecifier({}), false);
+	});
+});

--- a/test/rules/no-constant-actual.test.ts
+++ b/test/rules/no-constant-actual.test.ts
@@ -1,0 +1,471 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { noConstantActualRule } from "../../source/rules/no-constant-actual.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-constant-actual", noConstantActualRule, {
+	valid: [
+		// Correct argument order, one per covered method
+		"import assert from 'node:assert/strict'; assert.equal(actual, 'foo');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(actual, 42);",
+		"import assert from 'node:assert/strict'; assert.notEqual(actual, 'foo');",
+		"import assert from 'node:assert/strict'; assert.notStrictEqual(value, null);",
+		"import assert from 'node:assert/strict'; assert.deepEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.notDeepEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.notDeepStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.partialDeepStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.match(myString, /pattern/);",
+		"import assert from 'node:assert/strict'; assert.doesNotMatch(myString, /pattern/);",
+		"import assert from 'node:assert/strict'; assert.throws(() => fn(), Error);",
+		"import assert from 'node:assert/strict'; assert.doesNotThrow(() => fn(), Error);",
+		"import assert from 'node:assert/strict'; assert.rejects(asyncFn(), Error);",
+		"import assert from 'node:assert/strict'; assert.doesNotReject(asyncFn(), Error);",
+		"import assert from 'node:assert/strict'; assert.ifError(err);",
+
+		// Named imports in correct order
+		"import { strictEqual } from 'node:assert/strict'; strictEqual(actual, 42);",
+		"import { deepStrictEqual } from 'node:assert/strict'; deepStrictEqual(result, { ok: true });",
+		"import { ifError } from 'node:assert/strict'; ifError(err);",
+
+		// Renamed import in correct order
+		"import { strictEqual as eq } from 'node:assert/strict'; eq(actual, 42);",
+
+		// Various primitive constants on the expected side (correct order)
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, true);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, false);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, 42n);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, /foo/);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, null);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, NaN);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, Infinity);",
+
+		// Both sides non-constant: ambiguous, do not report
+		"import assert from 'node:assert/strict'; assert.strictEqual(foo(), bar());",
+		"import assert from 'node:assert/strict'; assert.strictEqual(obj.actual, obj.expected);",
+
+		// Actual side has dynamic content (so it is non-constant): do not report
+		// eslint-disable-next-line no-template-curly-in-string -- intentional template expression in fixture source
+		"import assert from 'node:assert/strict'; assert.strictEqual(`hi ${name}`, message);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(typeof actualThing, 'string');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(Symbol('x'), value);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(new Date(), value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual(new Date(42), value);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(obj.value, value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual({ a: foo }, value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual({ [k]: 1 }, value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual({ ...other }, value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual([foo], value);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual([...rest], value);",
+
+		// Three-argument form (actual, expected, message) in correct order
+		"import assert from 'node:assert/strict'; assert.strictEqual(actual, 42, 'message');",
+
+		// Insufficient arguments: nothing to report
+		"import assert from 'node:assert/strict'; assert.strictEqual(42);",
+		"import assert from 'node:assert/strict'; assert.strictEqual();",
+		"import assert from 'node:assert/strict'; assert.ifError();",
+
+		// Spread as the first argument: opaque, do not report
+		"import assert from 'node:assert/strict'; assert.strictEqual(...args);",
+		"import assert from 'node:assert/strict'; assert.ifError(...args);",
+
+		// Not from node:assert
+		"import { strictEqual } from 'somewhere-else'; strictEqual(42, actual);",
+		"import { ifError } from 'somewhere-else'; ifError('foo');",
+
+		// Method not in the targeted set
+		"import assert from 'node:assert/strict'; assert.ok(42, actual);",
+		"import assert from 'node:assert/strict'; assert.fail('boom');",
+
+		// Member call on an unrelated object
+		"const other = { strictEqual: () => {} }; other.strictEqual(42, actual);",
+		"const other = { ifError: () => {} }; other.ifError('foo');",
+
+		// Re-binding via const, computed member access, namespace alias, destructuring — all in correct order
+		"import assert from 'node:assert/strict'; assert['strictEqual'](actual, 42);",
+		"import assert from 'node:assert/strict'; const key = 'strictEqual'; assert[key](actual, 42);",
+		"import assert from 'node:assert/strict'; const a = assert; a.strictEqual(actual, 42);",
+		"import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(actual, 42);",
+		"import assert from 'node:assert/strict'; const { strictEqual: foo } = assert; foo(actual, 42);",
+		"import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(actual, 42);",
+		"import { strictEqual as foo } from 'node:assert/strict'; foo(actual, 42);",
+
+		// Bare module specifiers without the node: protocol
+		"import assert from 'assert/strict'; assert.strictEqual(actual, 42);",
+		"import assert from 'assert'; assert.strictEqual(actual, 42);",
+		"import { strictEqual } from 'assert/strict'; strictEqual(actual, 42);",
+
+		// Multi-hop alias chains
+		"import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(actual, 42);",
+		"import { strictEqual } from 'node:assert/strict'; const eq1 = strictEqual; const eq2 = eq1; eq2(actual, 42);",
+
+		// Computed access via template literal or constant expression
+		"import assert from 'node:assert/strict'; assert[`strictEqual`](actual, 42);",
+
+		// Computed member access where the property name cannot be resolved statically
+		"import assert from 'node:assert/strict'; assert[someKey](42, actual);",
+
+		// let-declared aliases are not tracked (could be reassigned)
+		"import assert from 'node:assert/strict'; let a = assert; a.strictEqual(42, actual);"
+	],
+	invalid: [
+		// Each two-argument method with autofix
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal('foo', result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.equal(result, 'foo');"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.notEqual('foo', result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.notEqual(result, 'foo');"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.notStrictEqual(null, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.notStrictEqual(value, null);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepEqual({ ok: true }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual({ ok: true }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.notDeepEqual({ ok: true }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.notDeepEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.notDeepStrictEqual({ ok: true }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.notDeepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.partialDeepStrictEqual({ ok: true }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.partialDeepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.match(/pattern/, myString);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.match(myString, /pattern/);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.doesNotMatch(/pattern/, myString);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.doesNotMatch(myString, /pattern/);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.throws({ message: 'foo' }, fn);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.throws(fn, { message: 'foo' });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.doesNotThrow({ message: 'foo' }, fn);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.doesNotThrow(fn, { message: 'foo' });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.rejects({ message: 'foo' }, asyncFn);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.rejects(asyncFn, { message: 'foo' });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.doesNotReject({ message: 'foo' }, asyncFn);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.doesNotReject(asyncFn, { message: 'foo' });"
+		},
+
+		// Named imports
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual } from 'node:assert/strict'; strictEqual(actual, 42);"
+		},
+		{
+			code: "import { strictEqual as eq } from 'node:assert/strict'; eq(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual as eq } from 'node:assert/strict'; eq(actual, 42);"
+		},
+
+		// Default + named import combined; both forms should fire
+		{
+			code: "import assert, { equal } from 'node:assert/strict'; assert.notEqual(42, value); equal('x', other);",
+			errors: [{ messageId: "no-constant-actual" }, { messageId: "no-constant-actual" }],
+			output: "import assert, { equal } from 'node:assert/strict'; assert.notEqual(value, 42); equal(other, 'x');"
+		},
+
+		// Non-strict node:assert and namespace import
+		{
+			code: "import assert from 'node:assert'; assert.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert'; assert.strictEqual(actual, 42);"
+		},
+		{
+			code: "import * as assert from 'node:assert/strict'; assert.equal('foo', result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import * as assert from 'node:assert/strict'; assert.equal(result, 'foo');"
+		},
+
+		// Primitive literal types
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(true, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, true);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(false, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, false);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(42n, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, 42n);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(/foo/, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, /foo/);"
+		},
+
+		// Constant identifiers
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(undefined, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, undefined);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(NaN, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, NaN);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(Infinity, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, Infinity);"
+		},
+
+		// Unary expressions over constants
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(-1, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, -1);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(-Infinity, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, -Infinity);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(!true, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, !true);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(void 0, value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, void 0);"
+		},
+
+		// Template literal without expressions
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(`hi`, message);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(message, `hi`);"
+		},
+
+		// `typeof` of a literal collapses to a constant string at runtime
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(typeof 'foo', value);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, typeof 'foo');"
+		},
+
+		// Empty / nested array and object literals
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual([], items);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(items, []);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual([1, 2, 3], items);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(items, [1, 2, 3]);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual({}, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, {});"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual({ a: { b: 1 } }, result);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { a: { b: 1 } });"
+		},
+
+		// Non-constant call expression as the second argument
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(42, foo());",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(foo(), 42);"
+		},
+
+		// Three-argument form with message
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(42, value, 'should match');",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert.strictEqual(value, 42, 'should match');"
+		},
+
+		// Comments between args disable the autofix
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(42 /* expected */, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: null
+		},
+
+		// Both arguments are constant: report with a distinct messageId, no autofix
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal('foo', 'bar');",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(1, 2);",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(NaN, NaN);",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual({ a: 1 }, { a: 2 });",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(typeof 'foo', 'string');",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.match('foo', /bar/);",
+			errors: [{ messageId: "constant-comparison" }],
+			output: null
+		},
+
+		// Weird usage patterns: computed access, alias, destructuring, re-binding
+		{
+			code: "import assert from 'node:assert/strict'; assert['strictEqual'](42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert['strictEqual'](actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const key = 'strictEqual'; assert[key](42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; const key = 'strictEqual'; assert[key](actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; a.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; const a = assert; a.strictEqual(actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual: foo } = assert; foo(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; const { strictEqual: foo } = assert; foo(actual, 42);"
+		},
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(actual, 42);"
+		},
+		{
+			code: "import { strictEqual as foo } from 'node:assert/strict'; foo(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual as foo } from 'node:assert/strict'; foo(actual, 42);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const { ifError } = assert; ifError('foo');",
+			errors: [{ messageId: "constant-actual" }],
+			output: null
+		},
+
+		// Bare module specifiers without the node: protocol
+		{
+			code: "import assert from 'assert/strict'; assert.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'assert/strict'; assert.strictEqual(actual, 42);"
+		},
+		{
+			code: "import assert from 'assert'; assert.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'assert'; assert.strictEqual(actual, 42);"
+		},
+		{
+			code: "import { strictEqual } from 'assert/strict'; strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual } from 'assert/strict'; strictEqual(actual, 42);"
+		},
+
+		// Multi-hop alias chains
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(actual, 42);"
+		},
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; const eq1 = strictEqual; const eq2 = eq1; eq2(42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import { strictEqual } from 'node:assert/strict'; const eq1 = strictEqual; const eq2 = eq1; eq2(actual, 42);"
+		},
+
+		// Computed access with a template literal or constant expression resolves via getStringIfConstant
+		{
+			code: "import assert from 'node:assert/strict'; assert[`strictEqual`](42, actual);",
+			errors: [{ messageId: "no-constant-actual" }],
+			output: "import assert from 'node:assert/strict'; assert[`strictEqual`](actual, 42);"
+		},
+
+		// ifError: single-argument method called with a constant value (no autofix)
+		{
+			code: "import assert from 'node:assert/strict'; assert.ifError('foo');",
+			errors: [{ messageId: "constant-actual" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ifError(null);",
+			errors: [{ messageId: "constant-actual" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ifError(undefined);",
+			errors: [{ messageId: "constant-actual" }],
+			output: null
+		},
+		{
+			code: "import { ifError } from 'node:assert/strict'; ifError(42);",
+			errors: [{ messageId: "constant-actual" }],
+			output: null
+		}
+	]
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -6,5 +6,5 @@
 		"rootDir": "."
 	},
 	"references": [{ "path": "../source/" }],
-	"include": ["./**/*.test.ts"]
+	"include": ["./**/*.test.ts", "./helpers/**/*.ts"]
 }


### PR DESCRIPTION
Implements the rule from #542 to flag assert calls whose first argument is a constant value (a likely actual/expected swap or a meaningless test). Covers the equality methods plus partialDeepStrictEqual, match/doesNotMatch, throws/doesNotThrow, rejects/doesNotReject, and ifError. Resolves bindings through both node:assert and bare assert specifiers, computed access, namespace aliases, destructuring, and const re-bindings.

The import/binding tracking and constant-detection helpers live in source/ast/ and source/node-assert/ so upcoming rules can share them, along with a test/helpers/linter-runner.ts probe-rule helper for unit testing utilities outside RuleTester.