### PR TITLE
Tighten require-strict tracking and share binding logic

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -1,1 +1,1 @@
-{ "words": ["TSES"] }
+{ "words": ["sonarjs", "TSES"] }

--- a/source/node-assert/method-tracker.ts
+++ b/source/node-assert/method-tracker.ts
@@ -1,121 +1,172 @@
 import { AST_NODE_TYPES, ASTUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
-import { isAssertModuleSpecifier } from "./modules.js";
 
-export type AssertBindingTrackerOptions = {
-	readonly isAssertMethod: (name: string) => boolean;
+export const NOT_ASSERT_MODULE: unique symbol = Symbol("not-assert-module");
+export type NotAssertModule = typeof NOT_ASSERT_MODULE;
+
+export type AssertBindingTrackerOptions<TMeta> = {
+	readonly isAssertMethod: (methodName: string) => boolean;
+	readonly classifyModule: (moduleSpecifier: unknown) => NotAssertModule | TMeta;
+	readonly resolveNamespaceProperty?: (propertyName: string, sourceMeta: TMeta) => TMeta | undefined;
 };
 
-export type AssertBindingTracker = {
+export type ResolvedMethodCall<TMeta> = {
+	readonly methodName: string;
+	readonly meta: TMeta;
+};
+
+export type AssertBindingTracker<TMeta> = {
 	readonly processImport: (node: Readonly<TSESTree.ImportDeclaration>) => void;
 	readonly processVariableDeclaration: (node: Readonly<TSESTree.VariableDeclaration>) => void;
 	readonly resolveMethodCall: (
 		callee: Readonly<TSESTree.Expression>,
 		// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to ESLint scope helpers that require the mutable Scope shape
 		scope: TSESLint.Scope.Scope
-	) => string | undefined;
+	) => ResolvedMethodCall<TMeta> | undefined;
 };
 
-type TrackerState = {
-	readonly namespaces: Set<string>;
-	readonly methodBindings: Map<string, string>;
-	readonly isAssertMethod: (name: string) => boolean;
+type NamespaceBinding<TMeta> = { readonly meta: TMeta };
+type MethodBinding<TMeta> = { readonly methodName: string; readonly meta: TMeta };
+
+type TrackerState<TMeta> = {
+	readonly namespaces: Map<string, NamespaceBinding<TMeta>>;
+	readonly methodBindings: Map<string, MethodBinding<TMeta>>;
+	readonly options: AssertBindingTrackerOptions<TMeta>;
 };
 
-function getDestructuredMethod(
-	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
-	isAssertMethod: (name: string) => boolean
-): { readonly localName: string; readonly methodName: string } | undefined {
+function getDestructuredAssignment(
+	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>
+): { readonly localName: string; readonly propertyName: string } | undefined {
 	if (property.type !== AST_NODE_TYPES.Property || property.computed) {
 		return undefined;
 	}
-	if (property.key.type !== AST_NODE_TYPES.Identifier || !isAssertMethod(property.key.name)) {
+	if (property.key.type !== AST_NODE_TYPES.Identifier || property.value.type !== AST_NODE_TYPES.Identifier) {
 		return undefined;
 	}
-	if (property.value.type !== AST_NODE_TYPES.Identifier) {
-		return undefined;
-	}
-	return { localName: property.value.name, methodName: property.key.name };
+	return { localName: property.value.name, propertyName: property.key.name };
 }
 
-function addDestructured(state: TrackerState, pattern: Readonly<TSESTree.ObjectPattern>): void {
+function applyKnownProperty<TMeta>(
+	state: TrackerState<TMeta>,
+	localName: string,
+	propertyName: string,
+	sourceMeta: TMeta
+): void {
+	const reExportMeta = state.options.resolveNamespaceProperty?.(propertyName, sourceMeta);
+	if (reExportMeta !== undefined) {
+		state.namespaces.set(localName, { meta: reExportMeta });
+		return;
+	}
+	if (state.options.isAssertMethod(propertyName)) {
+		state.methodBindings.set(localName, { methodName: propertyName, meta: sourceMeta });
+	}
+}
+
+function applyDestructuredProperty<TMeta>(
+	state: TrackerState<TMeta>,
+	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
+	sourceMeta: TMeta
+): void {
+	const assignment = getDestructuredAssignment(property);
+	if (assignment === undefined) {
+		return;
+	}
+	applyKnownProperty(state, assignment.localName, assignment.propertyName, sourceMeta);
+}
+
+function applyDestructured<TMeta>(
+	state: TrackerState<TMeta>,
+	pattern: Readonly<TSESTree.ObjectPattern>,
+	sourceMeta: TMeta
+): void {
 	for (const property of pattern.properties) {
-		const destructured = getDestructuredMethod(property, state.isAssertMethod);
-		if (destructured !== undefined) {
-			state.methodBindings.set(destructured.localName, destructured.methodName);
-		}
+		applyDestructuredProperty(state, property, sourceMeta);
 	}
 }
 
-function addImportSpecifier(state: TrackerState, specifier: Readonly<TSESTree.ImportClause>): void {
+function applyImportSpecifier<TMeta>(
+	state: TrackerState<TMeta>,
+	specifier: Readonly<TSESTree.ImportClause>,
+	sourceMeta: TMeta
+): void {
 	if (
 		specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
 		specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier
 	) {
-		state.namespaces.add(specifier.local.name);
+		state.namespaces.set(specifier.local.name, { meta: sourceMeta });
 		return;
 	}
 	if (specifier.imported.type !== AST_NODE_TYPES.Identifier) {
 		return;
 	}
-	if (state.isAssertMethod(specifier.imported.name)) {
-		state.methodBindings.set(specifier.local.name, specifier.imported.name);
-	}
+	applyKnownProperty(state, specifier.local.name, specifier.imported.name, sourceMeta);
 }
 
-function addFromNamespace(state: TrackerState, id: Readonly<TSESTree.Node>): void {
+function applyAliasFromNamespace<TMeta>(
+	state: TrackerState<TMeta>,
+	id: Readonly<TSESTree.Node>,
+	sourceMeta: TMeta
+): void {
 	if (id.type === AST_NODE_TYPES.Identifier) {
-		state.namespaces.add(id.name);
+		state.namespaces.set(id.name, { meta: sourceMeta });
 		return;
 	}
 	if (id.type === AST_NODE_TYPES.ObjectPattern) {
-		addDestructured(state, id);
+		applyDestructured(state, id, sourceMeta);
 	}
 }
 
-function addDeclarator(state: TrackerState, declarator: Readonly<TSESTree.VariableDeclarator>): void {
+function applyDeclarator<TMeta>(state: TrackerState<TMeta>, declarator: Readonly<TSESTree.VariableDeclarator>): void {
 	if (declarator.init?.type !== AST_NODE_TYPES.Identifier) {
 		return;
 	}
 	const sourceName = declarator.init.name;
-	if (state.namespaces.has(sourceName)) {
-		addFromNamespace(state, declarator.id);
+	const sourceNamespace = state.namespaces.get(sourceName);
+	if (sourceNamespace !== undefined) {
+		applyAliasFromNamespace(state, declarator.id, sourceNamespace.meta);
 		return;
 	}
-	const aliased = state.methodBindings.get(sourceName);
-	if (aliased !== undefined && declarator.id.type === AST_NODE_TYPES.Identifier) {
-		state.methodBindings.set(declarator.id.name, aliased);
+	const aliasedMethod = state.methodBindings.get(sourceName);
+	if (aliasedMethod !== undefined && declarator.id.type === AST_NODE_TYPES.Identifier) {
+		state.methodBindings.set(declarator.id.name, aliasedMethod);
 	}
 }
 
-function resolveMemberMethod(
-	state: TrackerState,
+function resolveMemberMethod<TMeta>(
+	state: TrackerState<TMeta>,
 	callee: Readonly<TSESTree.MemberExpression>,
 	// eslint-disable-next-line functional/prefer-immutable-types -- ESLint's getPropertyName needs the mutable Scope shape
 	scope: TSESLint.Scope.Scope
-): string | undefined {
-	if (callee.object.type !== AST_NODE_TYPES.Identifier || !state.namespaces.has(callee.object.name)) {
+): ResolvedMethodCall<TMeta> | undefined {
+	if (callee.object.type !== AST_NODE_TYPES.Identifier) {
+		return undefined;
+	}
+	const namespace = state.namespaces.get(callee.object.name);
+	if (namespace === undefined) {
 		return undefined;
 	}
 	const propertyName = ASTUtils.getPropertyName(callee, scope);
-	if (propertyName === null || !state.isAssertMethod(propertyName)) {
+	if (propertyName === null || !state.options.isAssertMethod(propertyName)) {
 		return undefined;
 	}
-	return propertyName;
+	return { methodName: propertyName, meta: namespace.meta };
 }
 
-export function createAssertBindingTracker(options: AssertBindingTrackerOptions): AssertBindingTracker {
-	const state: TrackerState = {
-		namespaces: new Set<string>(),
-		methodBindings: new Map<string, string>(),
-		isAssertMethod: options.isAssertMethod
+export function createAssertBindingTracker<TMeta>(
+	options: AssertBindingTrackerOptions<TMeta>
+): AssertBindingTracker<TMeta> {
+	const state: TrackerState<TMeta> = {
+		namespaces: new Map(),
+		methodBindings: new Map(),
+		options
 	};
 
 	function processImport(node: Readonly<TSESTree.ImportDeclaration>): void {
-		if (!isAssertModuleSpecifier(node.source.value)) {
+		const classification = options.classifyModule(node.source.value);
+		if (classification === NOT_ASSERT_MODULE) {
 			return;
 		}
 		for (const specifier of node.specifiers) {
-			addImportSpecifier(state, specifier);
+			applyImportSpecifier(state, specifier, classification);
 		}
 	}
 
@@ -124,7 +175,7 @@ export function createAssertBindingTracker(options: AssertBindingTrackerOptions)
 			return;
 		}
 		for (const declarator of node.declarations) {
-			addDeclarator(state, declarator);
+			applyDeclarator(state, declarator);
 		}
 	}
 
@@ -132,7 +183,7 @@ export function createAssertBindingTracker(options: AssertBindingTrackerOptions)
 		callee: Readonly<TSESTree.Expression>,
 		// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to ESLint scope helpers
 		scope: TSESLint.Scope.Scope
-	): string | undefined {
+	): ResolvedMethodCall<TMeta> | undefined {
 		if (callee.type === AST_NODE_TYPES.MemberExpression) {
 			return resolveMemberMethod(state, callee, scope);
 		}

--- a/source/rules/no-constant-actual.ts
+++ b/source/rules/no-constant-actual.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
 import { isConstant } from "../ast/is-constant.js";
-import { createAssertBindingTracker } from "../node-assert/method-tracker.js";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../node-assert/method-tracker.js";
+import { isAssertModuleSpecifier } from "../node-assert/modules.js";
 
 const createRule = ESLintUtils.RuleCreator((name) => {
 	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
@@ -99,7 +100,12 @@ export const noConstantActualRule = createRule({
 	defaultOptions: [],
 
 	create(context) {
-		const tracker = createAssertBindingTracker({ isAssertMethod: isAssertMethodName });
+		const tracker = createAssertBindingTracker<null>({
+			isAssertMethod: isAssertMethodName,
+			classifyModule(specifier) {
+				return isAssertModuleSpecifier(specifier) ? null : NOT_ASSERT_MODULE;
+			}
+		});
 		const { sourceCode } = context;
 
 		function reportSwap(
@@ -143,11 +149,11 @@ export const noConstantActualRule = createRule({
 			ImportDeclaration: tracker.processImport,
 			VariableDeclaration: tracker.processVariableDeclaration,
 			CallExpression(node) {
-				const methodName = tracker.resolveMethodCall(node.callee, sourceCode.getScope(node));
-				if (methodName === undefined) {
+				const resolved = tracker.resolveMethodCall(node.callee, sourceCode.getScope(node));
+				if (resolved === undefined) {
 					return;
 				}
-				if (ONE_ARG_METHODS.has(methodName)) {
+				if (ONE_ARG_METHODS.has(resolved.methodName)) {
 					handleOneArgCall(node);
 					return;
 				}

--- a/source/rules/require-strict.ts
+++ b/source/rules/require-strict.ts
@@ -1,5 +1,5 @@
-/* eslint-disable complexity, max-statements -- binding resolution requires explicit guarded branches */
-import { AST_NODE_TYPES, ASTUtils, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../node-assert/method-tracker.js";
 
 type AssertMode = "explicit" | "semantic";
 type RequireStrictOptions = readonly [
@@ -7,16 +7,6 @@ type RequireStrictOptions = readonly [
 		readonly mode?: AssertMode;
 	}
 ];
-
-type AssertionMethodCall = {
-	readonly methodName: string;
-	readonly fromStrictBinding: boolean;
-};
-
-type BindingState = {
-	readonly namespaceStrictnessByName: Map<string, boolean>;
-	readonly methodBindingByName: Map<string, AssertionMethodCall>;
-};
 
 const createRule = ESLintUtils.RuleCreator((name) => {
 	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
@@ -39,172 +29,61 @@ const STRICT_METHOD_NAMES: ReadonlySet<string> = new Set([
 const STRICT_MODULE_SPECIFIERS: ReadonlySet<string> = new Set(["node:assert/strict", "assert/strict"]);
 const BASE_MODULE_SPECIFIERS: ReadonlySet<string> = new Set(["node:assert", "assert"]);
 
-function isStrictModuleSpecifier(moduleSpecifier: unknown): moduleSpecifier is string {
-	return typeof moduleSpecifier === "string" && STRICT_MODULE_SPECIFIERS.has(moduleSpecifier);
+function isAssertMethodName(name: string): boolean {
+	return LEGACY_TO_STRICT_METHOD_NAME.has(name) || STRICT_METHOD_NAMES.has(name);
 }
 
-function isBaseModuleSpecifier(moduleSpecifier: unknown): moduleSpecifier is string {
-	return typeof moduleSpecifier === "string" && BASE_MODULE_SPECIFIERS.has(moduleSpecifier);
+// eslint-disable-next-line sonarjs/function-return-type -- the sentinel signals "not an assert module" and is intentionally distinct from the boolean strictness meta
+function classifyModule(moduleSpecifier: unknown): boolean | typeof NOT_ASSERT_MODULE {
+	if (typeof moduleSpecifier !== "string") {
+		return NOT_ASSERT_MODULE;
+	}
+	if (STRICT_MODULE_SPECIFIERS.has(moduleSpecifier)) {
+		return true;
+	}
+	if (BASE_MODULE_SPECIFIERS.has(moduleSpecifier)) {
+		return false;
+	}
+	return NOT_ASSERT_MODULE;
 }
 
-function getMethodImportName(specifier: Readonly<TSESTree.ImportSpecifier>): string | undefined {
-	if (specifier.imported.type !== AST_NODE_TYPES.Identifier) {
-		return undefined;
-	}
-	if (specifier.imported.name === "strict") {
-		return undefined;
-	}
-	if (LEGACY_TO_STRICT_METHOD_NAME.has(specifier.imported.name) || STRICT_METHOD_NAMES.has(specifier.imported.name)) {
-		return specifier.imported.name;
+function resolveStrictReExport(propertyName: string): boolean | undefined {
+	if (propertyName === "strict") {
+		return true;
 	}
 	return undefined;
 }
 
-function getDestructuredAssertionMethodBinding(
-	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
-	strictNamespaceBinding: boolean
-): { readonly localName: string; readonly assertionMethodCall: AssertionMethodCall } | undefined {
-	if (property.type !== AST_NODE_TYPES.Property || property.computed) {
-		return undefined;
+/* eslint-disable complexity -- explicit guarded branches per autofix shape make this clearer than splitting */
+function buildPropertyReplacementFix(
+	callee: Readonly<TSESTree.MemberExpression>,
+	strictMethodName: string
+): TSESLint.ReportFixFunction | null {
+	const { property } = callee;
+	if (property.type === AST_NODE_TYPES.Identifier && !callee.computed) {
+		return (fixer) => {
+			return fixer.replaceText(property, strictMethodName);
+		};
 	}
-	if (property.key.type !== AST_NODE_TYPES.Identifier || property.value.type !== AST_NODE_TYPES.Identifier) {
-		return undefined;
+	if (property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
+		return (fixer) => {
+			return fixer.replaceText(property, `'${strictMethodName}'`);
+		};
 	}
-	const { name: methodName } = property.key;
-	if (!LEGACY_TO_STRICT_METHOD_NAME.has(methodName) && !STRICT_METHOD_NAMES.has(methodName)) {
-		return undefined;
+	if (property.type === AST_NODE_TYPES.TemplateLiteral && property.expressions.length === 0) {
+		return (fixer) => {
+			return fixer.replaceText(property, `\`${strictMethodName}\``);
+		};
 	}
-	return {
-		localName: property.value.name,
-		assertionMethodCall: {
-			methodName,
-			fromStrictBinding: strictNamespaceBinding || STRICT_METHOD_NAMES.has(methodName)
-		}
-	};
+	return null;
 }
+/* eslint-enable complexity -- re-enable for the rest of the file */
 
-function getStrictReExportLocalName(
-	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>
-): string | undefined {
-	if (property.type !== AST_NODE_TYPES.Property || property.computed) {
-		return undefined;
+function buildFix(callee: Readonly<TSESTree.Expression>, strictMethodName: string): TSESLint.ReportFixFunction | null {
+	if (callee.type !== AST_NODE_TYPES.MemberExpression) {
+		return null;
 	}
-	if (property.key.type !== AST_NODE_TYPES.Identifier || property.key.name !== "strict") {
-		return undefined;
-	}
-	if (property.value.type !== AST_NODE_TYPES.Identifier) {
-		return undefined;
-	}
-	return property.value.name;
-}
-
-function applyDestructuredProperty(
-	state: BindingState,
-	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
-	strictNamespaceBinding: boolean
-): void {
-	const strictReExportLocalName = getStrictReExportLocalName(property);
-	if (strictReExportLocalName !== undefined) {
-		state.namespaceStrictnessByName.set(strictReExportLocalName, true);
-		return;
-	}
-	const destructuredMethodBinding = getDestructuredAssertionMethodBinding(property, strictNamespaceBinding);
-	if (destructuredMethodBinding !== undefined) {
-		state.methodBindingByName.set(
-			destructuredMethodBinding.localName,
-			destructuredMethodBinding.assertionMethodCall
-		);
-	}
-}
-
-function copyNamespaceBinding(
-	state: BindingState,
-	targetNode: Readonly<TSESTree.Node>,
-	strictNamespaceBinding: boolean
-): void {
-	if (targetNode.type === AST_NODE_TYPES.Identifier) {
-		state.namespaceStrictnessByName.set(targetNode.name, strictNamespaceBinding);
-		return;
-	}
-	if (targetNode.type !== AST_NODE_TYPES.ObjectPattern) {
-		return;
-	}
-	for (const property of targetNode.properties) {
-		applyDestructuredProperty(state, property, strictNamespaceBinding);
-	}
-}
-
-function processImportDeclaration(state: BindingState, node: Readonly<TSESTree.ImportDeclaration>): void {
-	const moduleSpecifier = node.source.value;
-	if (!isStrictModuleSpecifier(moduleSpecifier) && !isBaseModuleSpecifier(moduleSpecifier)) {
-		return;
-	}
-
-	const importedFromStrictModule = isStrictModuleSpecifier(moduleSpecifier);
-	for (const specifier of node.specifiers) {
-		if (
-			specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier ||
-			specifier.type === AST_NODE_TYPES.ImportNamespaceSpecifier
-		) {
-			state.namespaceStrictnessByName.set(specifier.local.name, importedFromStrictModule);
-		} else if (specifier.imported.type === AST_NODE_TYPES.Identifier && specifier.imported.name === "strict") {
-			state.namespaceStrictnessByName.set(specifier.local.name, true);
-		} else {
-			const methodName = getMethodImportName(specifier);
-			if (methodName !== undefined) {
-				state.methodBindingByName.set(specifier.local.name, {
-					methodName,
-					fromStrictBinding: importedFromStrictModule || STRICT_METHOD_NAMES.has(methodName)
-				});
-			}
-		}
-	}
-}
-
-function processVariableDeclaration(state: BindingState, node: Readonly<TSESTree.VariableDeclaration>): void {
-	if (node.kind !== "const") {
-		return;
-	}
-	for (const declarator of node.declarations) {
-		if (declarator.init?.type === AST_NODE_TYPES.Identifier) {
-			const sourceIdentifierName = declarator.init.name;
-			const strictNamespaceBinding = state.namespaceStrictnessByName.get(sourceIdentifierName);
-			if (strictNamespaceBinding !== undefined) {
-				copyNamespaceBinding(state, declarator.id, strictNamespaceBinding);
-			} else if (declarator.id.type === AST_NODE_TYPES.Identifier) {
-				const methodBinding = state.methodBindingByName.get(sourceIdentifierName);
-				if (methodBinding !== undefined) {
-					state.methodBindingByName.set(declarator.id.name, methodBinding);
-				}
-			}
-		}
-	}
-}
-
-function resolveCall(
-	state: BindingState,
-	callee: Readonly<TSESTree.Expression>,
-	// eslint-disable-next-line functional/prefer-immutable-types -- required by ESLint scope utilities
-	scope: TSESLint.Scope.Scope
-): AssertionMethodCall | undefined {
-	if (callee.type === AST_NODE_TYPES.Identifier) {
-		return state.methodBindingByName.get(callee.name);
-	}
-	if (callee.type !== AST_NODE_TYPES.MemberExpression || callee.object.type !== AST_NODE_TYPES.Identifier) {
-		return undefined;
-	}
-	const strictness = state.namespaceStrictnessByName.get(callee.object.name);
-	if (strictness === undefined) {
-		return undefined;
-	}
-	const propertyName = ASTUtils.getPropertyName(callee, scope);
-	if (propertyName === null) {
-		return undefined;
-	}
-	if (!LEGACY_TO_STRICT_METHOD_NAME.has(propertyName) && !STRICT_METHOD_NAMES.has(propertyName)) {
-		return undefined;
-	}
-	return { methodName: propertyName, fromStrictBinding: strictness || STRICT_METHOD_NAMES.has(propertyName) };
+	return buildPropertyReplacementFix(callee, strictMethodName);
 }
 
 export const requireStrictRule = createRule<RequireStrictOptions, "require-strict">({
@@ -234,59 +113,44 @@ export const requireStrictRule = createRule<RequireStrictOptions, "require-stric
 	defaultOptions: [{ mode: "semantic" }],
 	create(context, options) {
 		const mode = options[0].mode ?? "semantic";
-		const state: BindingState = {
-			namespaceStrictnessByName: new Map<string, boolean>(),
-			methodBindingByName: new Map<string, AssertionMethodCall>()
-		};
+		const tracker = createAssertBindingTracker<boolean>({
+			isAssertMethod: isAssertMethodName,
+			classifyModule,
+			resolveNamespaceProperty: resolveStrictReExport
+		});
 		const { sourceCode } = context;
 
+		function reportLegacyCall(
+			node: Readonly<TSESTree.CallExpression>,
+			legacyMethodName: string,
+			strictMethodName: string
+		): void {
+			context.report({
+				messageId: "require-strict",
+				node,
+				data: { legacyMethodName, strictMethodName },
+				fix: buildFix(node.callee, strictMethodName)
+			});
+		}
+
 		return {
-			ImportDeclaration(node) {
-				processImportDeclaration(state, node);
-			},
-			VariableDeclaration(node) {
-				processVariableDeclaration(state, node);
-			},
+			ImportDeclaration: tracker.processImport,
+			VariableDeclaration: tracker.processVariableDeclaration,
 			CallExpression(node) {
-				const assertionMethodCall = resolveCall(state, node.callee, sourceCode.getScope(node));
-				if (assertionMethodCall === undefined) {
+				const resolved = tracker.resolveMethodCall(node.callee, sourceCode.getScope(node));
+				if (resolved === undefined) {
 					return;
 				}
-				const strictMethodName = LEGACY_TO_STRICT_METHOD_NAME.get(assertionMethodCall.methodName);
+				const strictMethodName = LEGACY_TO_STRICT_METHOD_NAME.get(resolved.methodName);
 				if (strictMethodName === undefined) {
 					return;
 				}
-				const shouldReport = mode === "explicit" ? true : !assertionMethodCall.fromStrictBinding;
+				const shouldReport = mode === "explicit" || !resolved.meta;
 				if (!shouldReport) {
 					return;
 				}
-
-				context.report({
-					messageId: "require-strict",
-					node,
-					data: {
-						legacyMethodName: assertionMethodCall.methodName,
-						strictMethodName
-					},
-					fix(fixer) {
-						if (node.callee.type === AST_NODE_TYPES.MemberExpression) {
-							const { property } = node.callee;
-							if (property.type === AST_NODE_TYPES.Identifier && !node.callee.computed) {
-								return fixer.replaceText(property, strictMethodName);
-							}
-							if (property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
-								return fixer.replaceText(property, `'${strictMethodName}'`);
-							}
-							if (property.type === AST_NODE_TYPES.TemplateLiteral && property.expressions.length === 0) {
-								return fixer.replaceText(property, `\`${strictMethodName}\``);
-							}
-							return null;
-						}
-						return null;
-					}
-				});
+				reportLegacyCall(node, resolved.methodName, strictMethodName);
 			}
 		};
 	}
 });
-/* eslint-enable complexity, max-statements -- re-enable for the rest of the codebase */

--- a/source/rules/require-strict.ts
+++ b/source/rules/require-strict.ts
@@ -83,6 +83,40 @@ function getDestructuredAssertionMethodBinding(
 	};
 }
 
+function getStrictReExportLocalName(
+	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>
+): string | undefined {
+	if (property.type !== AST_NODE_TYPES.Property || property.computed) {
+		return undefined;
+	}
+	if (property.key.type !== AST_NODE_TYPES.Identifier || property.key.name !== "strict") {
+		return undefined;
+	}
+	if (property.value.type !== AST_NODE_TYPES.Identifier) {
+		return undefined;
+	}
+	return property.value.name;
+}
+
+function applyDestructuredProperty(
+	state: BindingState,
+	property: Readonly<TSESTree.ObjectLiteralElement | TSESTree.RestElement>,
+	strictNamespaceBinding: boolean
+): void {
+	const strictReExportLocalName = getStrictReExportLocalName(property);
+	if (strictReExportLocalName !== undefined) {
+		state.namespaceStrictnessByName.set(strictReExportLocalName, true);
+		return;
+	}
+	const destructuredMethodBinding = getDestructuredAssertionMethodBinding(property, strictNamespaceBinding);
+	if (destructuredMethodBinding !== undefined) {
+		state.methodBindingByName.set(
+			destructuredMethodBinding.localName,
+			destructuredMethodBinding.assertionMethodCall
+		);
+	}
+}
+
 function copyNamespaceBinding(
 	state: BindingState,
 	targetNode: Readonly<TSESTree.Node>,
@@ -96,13 +130,7 @@ function copyNamespaceBinding(
 		return;
 	}
 	for (const property of targetNode.properties) {
-		const destructuredMethodBinding = getDestructuredAssertionMethodBinding(property, strictNamespaceBinding);
-		if (destructuredMethodBinding !== undefined) {
-			state.methodBindingByName.set(
-				destructuredMethodBinding.localName,
-				destructuredMethodBinding.assertionMethodCall
-			);
-		}
+		applyDestructuredProperty(state, property, strictNamespaceBinding);
 	}
 }
 

--- a/test/node-assert/method-tracker.test.ts
+++ b/test/node-assert/method-tracker.test.ts
@@ -2,7 +2,8 @@ import * as assert from "node:assert/strict";
 import { suite, test } from "mocha";
 import type { Rule } from "eslint";
 import type { TSESLint, TSESTree } from "@typescript-eslint/utils";
-import { createAssertBindingTracker } from "../../source/node-assert/method-tracker.js";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../../source/node-assert/method-tracker.js";
+import { isAssertModuleSpecifier } from "../../source/node-assert/modules.js";
 import { expectNoLintFailure, runProbeRule } from "../helpers/linter-runner.js";
 
 const ASSERT_METHODS: ReadonlySet<string> = new Set(["strictEqual", "deepStrictEqual", "ifError"]);
@@ -11,16 +12,46 @@ function isAssertMethod(name: string): boolean {
 	return ASSERT_METHODS.has(name);
 }
 
-type ResolvedCall = {
+// eslint-disable-next-line sonarjs/function-return-type -- the sentinel signals "not an assert module" and is intentionally distinct from the boolean strictness meta
+function classifyStrictness(specifier: unknown): boolean | typeof NOT_ASSERT_MODULE {
+	if (specifier === "node:assert" || specifier === "assert") {
+		return false;
+	}
+	if (specifier === "node:assert/strict" || specifier === "assert/strict") {
+		return true;
+	}
+	return NOT_ASSERT_MODULE;
+}
+
+type ResolvedCall<TMeta> = {
 	readonly calleeText: string;
 	readonly resolvedMethod: string | undefined;
+	readonly meta: TMeta | undefined;
 };
 
-function resolveCallsIn(code: string): readonly ResolvedCall[] {
-	const calls: ResolvedCall[] = [];
+type ProbeOptions<TMeta> = {
+	readonly classifyModule?: (specifier: unknown) => TMeta | typeof NOT_ASSERT_MODULE;
+	readonly resolveNamespaceProperty?: (propertyName: string, sourceMeta: TMeta) => TMeta | undefined;
+};
+
+function resolveCallsIn<TMeta = null>(
+	code: string,
+	probeOptions: ProbeOptions<TMeta> = {}
+): readonly ResolvedCall<TMeta>[] {
+	const classifyModule =
+		probeOptions.classifyModule ??
+		((specifier: unknown): TMeta | typeof NOT_ASSERT_MODULE => {
+			return isAssertModuleSpecifier(specifier) ? (null as TMeta) : NOT_ASSERT_MODULE;
+		});
+	const calls: ResolvedCall<TMeta>[] = [];
 	const probeRule: Rule.RuleModule = {
 		create(context) {
-			const tracker = createAssertBindingTracker({ isAssertMethod });
+			const baseOptions = { isAssertMethod, classifyModule } as const;
+			const tracker = createAssertBindingTracker<TMeta>(
+				probeOptions.resolveNamespaceProperty === undefined
+					? baseOptions
+					: { ...baseOptions, resolveNamespaceProperty: probeOptions.resolveNamespaceProperty }
+			);
 			return {
 				ImportDeclaration(node) {
 					tracker.processImport(node as unknown as TSESTree.ImportDeclaration);
@@ -34,7 +65,8 @@ function resolveCallsIn(code: string): readonly ResolvedCall[] {
 					const resolved = tracker.resolveMethodCall(calleeNode as unknown as TSESTree.Expression, scope);
 					calls.push({
 						calleeText: context.sourceCode.getText(calleeNode),
-						resolvedMethod: resolved
+						resolvedMethod: resolved?.methodName,
+						meta: resolved?.meta
 					});
 				}
 			};
@@ -170,6 +202,78 @@ suite("createAssertBindingTracker()", function () {
 			);
 			assert.strictEqual(calls[0]?.resolvedMethod, undefined);
 			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+		});
+	});
+
+	suite("namespace metadata", function () {
+		test("propagates module-level metadata through default imports", function () {
+			const baseCalls = resolveCallsIn<boolean>("import assert from 'node:assert'; assert.strictEqual(1, 2);", {
+				classifyModule: classifyStrictness
+			});
+			assert.strictEqual(baseCalls[0]?.meta, false);
+
+			const strictCalls = resolveCallsIn<boolean>(
+				"import assert from 'node:assert/strict'; assert.strictEqual(1, 2);",
+				{ classifyModule: classifyStrictness }
+			);
+			assert.strictEqual(strictCalls[0]?.meta, true);
+		});
+
+		test("propagates metadata through alias chains and destructuring", function () {
+			const calls = resolveCallsIn<boolean>(
+				"import assert from 'node:assert/strict'; const a = assert; const b = a; const { strictEqual } = b; strictEqual(1, 2); b.deepStrictEqual({}, {});",
+				{ classifyModule: classifyStrictness }
+			);
+			assert.strictEqual(calls[0]?.meta, true);
+			assert.strictEqual(calls[1]?.meta, true);
+		});
+
+		test("attaches the source module metadata to method bindings from named imports", function () {
+			const calls = resolveCallsIn<boolean>("import { strictEqual } from 'node:assert'; strictEqual(1, 2);", {
+				classifyModule: classifyStrictness
+			});
+			assert.strictEqual(calls[0]?.meta, false);
+		});
+	});
+
+	suite("resolveNamespaceProperty hook", function () {
+		function resolveStrictReExport(propertyName: string): boolean | undefined {
+			return propertyName === "strict" ? true : undefined;
+		}
+
+		test("registers a re-exported namespace through a named import", function () {
+			const calls = resolveCallsIn<boolean>("import { strict } from 'node:assert'; strict.strictEqual(1, 2);", {
+				classifyModule: classifyStrictness,
+				resolveNamespaceProperty: resolveStrictReExport
+			});
+			assert.strictEqual(calls[0]?.resolvedMethod, "strictEqual");
+			assert.strictEqual(calls[0].meta, true);
+		});
+
+		test("registers a re-exported namespace through const destructuring", function () {
+			const calls = resolveCallsIn<boolean>(
+				"import assert from 'node:assert'; const { strict } = assert; strict.strictEqual(1, 2);",
+				{ classifyModule: classifyStrictness, resolveNamespaceProperty: resolveStrictReExport }
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+			assert.strictEqual(calls.at(-1)?.meta, true);
+		});
+
+		test("registers a renamed re-exported namespace through const destructuring", function () {
+			const calls = resolveCallsIn<boolean>(
+				"import assert from 'node:assert'; const { strict: s } = assert; s.strictEqual(1, 2);",
+				{ classifyModule: classifyStrictness, resolveNamespaceProperty: resolveStrictReExport }
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, "strictEqual");
+			assert.strictEqual(calls.at(-1)?.meta, true);
+		});
+
+		test("does not register a re-export when the hook returns undefined", function () {
+			const calls = resolveCallsIn<boolean>(
+				"import assert from 'node:assert'; const { something } = assert; something.strictEqual(1, 2);",
+				{ classifyModule: classifyStrictness, resolveNamespaceProperty: resolveStrictReExport }
+			);
+			assert.strictEqual(calls.at(-1)?.resolvedMethod, undefined);
 		});
 	});
 });

--- a/test/rules/consistent-import.test.ts
+++ b/test/rules/consistent-import.test.ts
@@ -5,12 +5,47 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("consistent-import", consistentImportRule, {
 	valid: [
+		// Default style is "strict-module"
 		"import assert from 'node:assert/strict';",
+		"import assert from 'assert/strict';",
+		"import { equal } from 'node:assert/strict';",
 		"import { equal } from 'assert/strict';",
+		"import * as assert from 'node:assert/strict';",
+		"import 'node:assert/strict';",
+		"import assert, { equal } from 'node:assert/strict';",
+
+		// Imports from unrelated modules are out of scope
+		"import { strict } from 'somewhere-else';",
+		"import assert from 'somewhere-else';",
+		"import * as assert from 'somewhere-else';",
+
+		// style: base — base specifier, no `strict` named import
 		{
 			code: "import assert from 'node:assert';",
 			options: [{ style: "base" }]
 		},
+		{
+			code: "import assert from 'assert';",
+			options: [{ style: "base" }]
+		},
+		{
+			code: "import { equal } from 'node:assert';",
+			options: [{ style: "base" }]
+		},
+		{
+			code: "import * as assert from 'node:assert';",
+			options: [{ style: "base" }]
+		},
+		{
+			code: "import 'node:assert';",
+			options: [{ style: "base" }]
+		},
+		{
+			code: "import assert, { equal } from 'node:assert';",
+			options: [{ style: "base" }]
+		},
+
+		// style: strict-export — base specifier with the `strict` named import
 		{
 			code: "import { strict as assert } from 'node:assert';",
 			options: [{ style: "strict-export" }]
@@ -18,15 +53,66 @@ ruleTester.run("consistent-import", consistentImportRule, {
 		{
 			code: "import { strict } from 'assert';",
 			options: [{ style: "strict-export" }]
+		},
+		{
+			code: "import { strict } from 'node:assert';",
+			options: [{ style: "strict-export" }]
+		},
+		{
+			code: "import { strict, equal } from 'node:assert';",
+			options: [{ style: "strict-export" }]
+		},
+		{
+			code: "import assert, { strict } from 'node:assert';",
+			options: [{ style: "strict-export" }]
+		},
+
+		// style: strict-module — explicit reaffirmation of the default
+		{
+			code: "import assert from 'node:assert/strict';",
+			options: [{ style: "strict-module" }]
 		}
 	],
 	invalid: [
+		// Default style: strict-module
 		{
 			code: "import assert from 'node:assert';",
 			errors: [{ messageId: "consistent-import" }]
 		},
 		{
+			code: "import assert from 'assert';",
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { equal } from 'node:assert';",
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { strict } from 'node:assert';",
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import * as assert from 'node:assert';",
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import 'node:assert';",
+			errors: [{ messageId: "consistent-import" }]
+		},
+
+		// style: base — strict module specifiers and `strict` named imports are forbidden
+		{
 			code: "import assert from 'node:assert/strict';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import assert from 'assert/strict';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { equal } from 'assert/strict';",
 			options: [{ style: "base" }],
 			errors: [{ messageId: "consistent-import" }]
 		},
@@ -36,6 +122,28 @@ ruleTester.run("consistent-import", consistentImportRule, {
 			errors: [{ messageId: "consistent-import" }]
 		},
 		{
+			code: "import { strict } from 'node:assert';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { strict, equal } from 'node:assert';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import assert, { strict } from 'node:assert';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import 'node:assert/strict';",
+			options: [{ style: "base" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+
+		// style: strict-export — anything that isn't a base specifier with the `strict` named import
+		{
 			code: "import assert from 'node:assert';",
 			options: [{ style: "strict-export" }],
 			errors: [{ messageId: "consistent-import" }]
@@ -43,6 +151,48 @@ ruleTester.run("consistent-import", consistentImportRule, {
 		{
 			code: "import assert from 'node:assert/strict';",
 			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { equal } from 'node:assert';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import * as assert from 'node:assert';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { strict } from 'node:assert/strict';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { strict as foo } from 'assert/strict';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import 'node:assert';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import 'node:assert/strict';",
+			options: [{ style: "strict-export" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+
+		// style: strict-module explicit
+		{
+			code: "import assert from 'node:assert';",
+			options: [{ style: "strict-module" }],
+			errors: [{ messageId: "consistent-import" }]
+		},
+		{
+			code: "import { strict } from 'node:assert';",
+			options: [{ style: "strict-module" }],
 			errors: [{ messageId: "consistent-import" }]
 		}
 	]

--- a/test/rules/require-strict.test.ts
+++ b/test/rules/require-strict.test.ts
@@ -5,48 +5,305 @@ const ruleTester = new RuleTester();
 
 ruleTester.run("require-strict", requireStrictRule, {
 	valid: [
+		// Already-strict bindings on either module (semantic default)
 		"import assert from 'node:assert'; assert.strictEqual(actual, expected);",
+		"import assert from 'node:assert'; assert.notStrictEqual(actual, expected);",
+		"import assert from 'node:assert'; assert.deepStrictEqual(actual, expected);",
+		"import assert from 'node:assert'; assert.notDeepStrictEqual(actual, expected);",
 		"import assert from 'node:assert/strict'; assert.equal(actual, expected);",
+		"import assert from 'node:assert/strict'; assert.notEqual(actual, expected);",
+		"import assert from 'node:assert/strict'; assert.deepEqual(actual, expected);",
+		"import assert from 'node:assert/strict'; assert.notDeepEqual(actual, expected);",
+
+		// Strict default re-export via named import
 		"import { strict as assert } from 'node:assert'; assert.deepEqual(actual, expected);",
+		"import { strict } from 'node:assert'; strict.equal(actual, expected);",
+
+		// Already-strict named imports from either module
 		"import { strictEqual } from 'node:assert'; strictEqual(actual, expected);",
+		"import { strictEqual } from 'node:assert/strict'; strictEqual(actual, expected);",
+
+		// Renamed already-strict named import
+		"import { strictEqual as eq } from 'node:assert'; eq(actual, expected);",
+
+		// Method imports from a strict module use legacy names safely (semantic)
+		"import { equal } from 'node:assert/strict'; equal(actual, expected);",
+		"import { equal as eq } from 'node:assert/strict'; eq(actual, expected);",
+
+		// Imports from unrelated modules are ignored
 		"import { equal } from 'somewhere'; equal(actual, expected);",
+		"import assert from 'somewhere'; assert.equal(actual, expected);",
+
+		// Namespace imports
+		"import * as assert from 'node:assert'; assert.strictEqual(actual, expected);",
+		"import * as assert from 'node:assert/strict'; assert.equal(actual, expected);",
+
+		// Bare specifiers without the node: protocol
+		"import assert from 'assert'; assert.strictEqual(actual, expected);",
+		"import assert from 'assert/strict'; assert.equal(actual, expected);",
+		"import { strictEqual } from 'assert'; strictEqual(actual, expected);",
+		"import { equal } from 'assert/strict'; equal(actual, expected);",
+
+		// Default + named combined
+		"import assert, { strictEqual } from 'node:assert'; assert.strictEqual(a, b); strictEqual(c, d);",
+
+		// Const aliases of namespaces
 		"import assert from 'node:assert'; const alias = assert; alias.strictEqual(actual, expected);",
+		"import assert from 'node:assert/strict'; const alias = assert; alias.equal(actual, expected);",
+
+		// Multi-hop alias chains preserve strictness
+		"import assert from 'node:assert/strict'; const a = assert; const b = a; b.equal(actual, expected);",
+		"import { equal } from 'node:assert/strict'; const eq1 = equal; const eq2 = eq1; eq2(actual, expected);",
+
+		// Strict namespace destructured from a base namespace
 		"import assert from 'node:assert'; const { strict } = assert; strict.equal(actual, expected);",
 		"import assert from 'node:assert'; const { strict: s } = assert; s.equal(actual, expected);",
+		"import assert from 'node:assert'; const { strict } = assert; const s = strict; s.equal(actual, expected);",
+
+		// Destructured method bindings from a strict namespace
+		"import assert from 'node:assert/strict'; const { equal } = assert; equal(actual, expected);",
+		"import assert from 'node:assert/strict'; const { equal: eq } = assert; eq(actual, expected);",
+
+		// Re-bound named imports keep their strictness
+		"import { strictEqual } from 'node:assert'; const eq = strictEqual; eq(actual, expected);",
+		"import { equal } from 'node:assert/strict'; const eq = equal; eq(actual, expected);",
+
+		// Methods outside the legacy mapping are ignored
+		"import assert from 'node:assert'; assert.match(actual, /x/);",
+		"import assert from 'node:assert'; assert.doesNotMatch(actual, /x/);",
+		"import assert from 'node:assert'; assert.ok(actual);",
+		"import assert from 'node:assert'; assert.ifError(actual);",
+		"import assert from 'node:assert'; assert.fail('boom');",
+		"import assert from 'node:assert'; assert.throws(() => fn(), Error);",
+		"import assert from 'node:assert'; assert.partialDeepStrictEqual(a, b);",
+
+		// Calls on unrelated objects must not be tracked
+		"const other = { equal: () => {} }; other.equal(actual, expected);",
+		"const other = { strictEqual: () => {} }; other.strictEqual(actual, expected);",
+
+		// `let`-declared aliases are not propagated (they could be reassigned)
+		"import assert from 'node:assert'; let a = assert; a.equal(actual, expected);",
+		"import { equal } from 'node:assert'; let eq = equal; eq(actual, expected);",
+
+		// Computed access where the property name cannot be resolved statically
+		"import assert from 'node:assert'; assert[someKey](actual, expected);",
+
+		// Computed access via literal forms on already-strict bindings
+		"import assert from 'node:assert/strict'; assert['equal'](actual, expected);",
+		"import assert from 'node:assert/strict'; assert[`equal`](actual, expected);",
+		"import assert from 'node:assert/strict'; const k = 'equal'; assert[k](actual, expected);",
+
+		// Side-effect-only import: no specifiers, no crash
+		"import 'node:assert';",
+		"import 'node:assert/strict';",
+
+		// Calls before the import declaration cannot resolve a binding
+		"someOtherCall(actual, expected); import assert from 'node:assert/strict'; assert.equal(actual, expected);",
+
+		// Explicit option mode keeps already-strict calls valid
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(actual, expected);",
+			options: [{ mode: "explicit" }]
+		},
+		{
+			code: "import { strictEqual } from 'node:assert'; strictEqual(actual, expected);",
+			options: [{ mode: "explicit" }]
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.match(actual, /x/);",
+			options: [{ mode: "explicit" }]
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(actual, expected);",
+			options: [{ mode: "explicit" }]
+		},
+
+		// Semantic mode is the default; reaffirm one case for clarity
 		{
 			code: "import assert from 'node:assert/strict'; assert.equal(actual, expected);",
 			options: [{ mode: "semantic" }]
 		}
 	],
 	invalid: [
+		// Each legacy method via member access on a default import (autofixable)
 		{
 			code: "import assert from 'node:assert'; assert.equal(actual, expected);",
 			errors: [{ messageId: "require-strict" }],
 			output: "import assert from 'node:assert'; assert.strictEqual(actual, expected);"
 		},
 		{
+			code: "import assert from 'node:assert'; assert.notEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert.notStrictEqual(actual, expected);"
+		},
+		{
+			code: "import assert from 'node:assert'; assert.deepEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert.deepStrictEqual(actual, expected);"
+		},
+		{
+			code: "import assert from 'node:assert'; assert.notDeepEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert.notDeepStrictEqual(actual, expected);"
+		},
+
+		// Each legacy method via named import (no autofix on identifier callees)
+		{
 			code: "import { equal } from 'node:assert'; equal(actual, expected);",
-			errors: [{ messageId: "require-strict" }]
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+		{
+			code: "import { notEqual } from 'node:assert'; notEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+		{
+			code: "import { deepEqual } from 'node:assert'; deepEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+		{
+			code: "import { notDeepEqual } from 'node:assert'; notDeepEqual(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Renamed legacy named import is still flagged but the call site cannot be safely renamed
+		{
+			code: "import { equal as eq } from 'node:assert'; eq(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Namespace import with a legacy method
+		{
+			code: "import * as assert from 'node:assert'; assert.equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import * as assert from 'node:assert'; assert.strictEqual(actual, expected);"
+		},
+
+		// Bare specifiers without the node: protocol
+		{
+			code: "import assert from 'assert'; assert.equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'assert'; assert.strictEqual(actual, expected);"
+		},
+		{
+			code: "import { equal } from 'assert'; equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Default + named combined: every legacy call site is flagged
+		{
+			code: "import assert, { equal } from 'node:assert'; assert.equal(a, b); equal(c, d);",
+			errors: [{ messageId: "require-strict" }, { messageId: "require-strict" }],
+			output: "import assert, { equal } from 'node:assert'; assert.strictEqual(a, b); equal(c, d);"
+		},
+
+		// Const aliases of a base namespace propagate non-strictness
+		{
+			code: "import assert from 'node:assert'; const alias = assert; alias.equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; const alias = assert; alias.strictEqual(actual, expected);"
 		},
 		{
 			code: "import assert from 'node:assert'; const alias = assert; alias['deepEqual'](actual, expected);",
 			errors: [{ messageId: "require-strict" }],
 			output: "import assert from 'node:assert'; const alias = assert; alias['deepStrictEqual'](actual, expected);"
 		},
+
+		// Multi-hop alias chains
+		{
+			code: "import assert from 'node:assert'; const a = assert; const b = a; b.equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; const a = assert; const b = a; b.strictEqual(actual, expected);"
+		},
+		{
+			code: "import { equal } from 'node:assert'; const eq1 = equal; const eq2 = eq1; eq2(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Destructured method bindings from a base namespace
+		{
+			code: "import assert from 'node:assert'; const { equal } = assert; equal(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert'; const { equal: eq } = assert; eq(actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
 		{
 			code: "import assert from 'node:assert'; const { equal: strictEqual } = assert; strictEqual(actual, expected);",
-			errors: [{ messageId: "require-strict" }]
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Computed access via string and template literals
+		{
+			code: "import assert from 'node:assert'; assert['equal'](actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert['strictEqual'](actual, expected);"
 		},
 		{
-			code: "import assert from 'node:assert'; const key = 'equal'; assert[key](actual, expected);",
-			errors: [{ messageId: "require-strict" }]
+			code: "import assert from 'node:assert'; assert[`equal`](actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert[`strictEqual`](actual, expected);"
 		},
+
+		// Computed access via a const-bound key (resolved through getPropertyName)
+		{
+			code: "import assert from 'node:assert'; const key = 'equal'; assert[key](actual, expected);",
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+
+		// Three-argument form preserves the trailing message argument
+		{
+			code: "import assert from 'node:assert'; assert.equal(actual, expected, 'oops');",
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; assert.strictEqual(actual, expected, 'oops');"
+		},
+
+		// Strict default re-export via named import in explicit mode
+		{
+			code: "import { strict as s } from 'node:assert'; s.equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: "import { strict as s } from 'node:assert'; s.strictEqual(actual, expected);"
+		},
+		{
+			code: "import { strict } from 'node:assert'; strict.equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: "import { strict } from 'node:assert'; strict.strictEqual(actual, expected);"
+		},
+
+		// Explicit mode flags every legacy call site, even on a strict module
 		{
 			code: "import assert from 'node:assert/strict'; assert.equal(actual, expected);",
 			options: [{ mode: "explicit" }],
 			errors: [{ messageId: "require-strict" }],
 			output: "import assert from 'node:assert/strict'; assert.strictEqual(actual, expected);"
 		},
+		{
+			code: "import assert from 'node:assert/strict'; const { equal } = assert; equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; const b = a; b.equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(actual, expected);"
+		},
+
+		// Strict-namespace destructured from a base namespace (the bug fixed earlier)
 		{
 			code: "import assert from 'node:assert'; const { strict } = assert; strict.equal(actual, expected);",
 			options: [{ mode: "explicit" }],

--- a/test/rules/require-strict.test.ts
+++ b/test/rules/require-strict.test.ts
@@ -11,6 +11,8 @@ ruleTester.run("require-strict", requireStrictRule, {
 		"import { strictEqual } from 'node:assert'; strictEqual(actual, expected);",
 		"import { equal } from 'somewhere'; equal(actual, expected);",
 		"import assert from 'node:assert'; const alias = assert; alias.strictEqual(actual, expected);",
+		"import assert from 'node:assert'; const { strict } = assert; strict.equal(actual, expected);",
+		"import assert from 'node:assert'; const { strict: s } = assert; s.equal(actual, expected);",
 		{
 			code: "import assert from 'node:assert/strict'; assert.equal(actual, expected);",
 			options: [{ mode: "semantic" }]
@@ -44,6 +46,18 @@ ruleTester.run("require-strict", requireStrictRule, {
 			options: [{ mode: "explicit" }],
 			errors: [{ messageId: "require-strict" }],
 			output: "import assert from 'node:assert/strict'; assert.strictEqual(actual, expected);"
+		},
+		{
+			code: "import assert from 'node:assert'; const { strict } = assert; strict.equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; const { strict } = assert; strict.strictEqual(actual, expected);"
+		},
+		{
+			code: "import assert from 'node:assert'; const { strict: s } = assert; s.equal(actual, expected);",
+			options: [{ mode: "explicit" }],
+			errors: [{ messageId: "require-strict" }],
+			output: "import assert from 'node:assert'; const { strict: s } = assert; s.strictEqual(actual, expected);"
 		}
 	]
 });


### PR DESCRIPTION
## Summary

Follow-up to #552. While auditing the rules introduced by that PR I found one false negative in `require-strict` and a lot of binding-resolution edge cases that the rule actually handled but never asserted. `consistent-import` ships with no bug but a similarly thin test file. This PR ships four commits, each independently reviewable:

1. **Track strict re-exports through const destructuring** — `const { strict } = assert; strict.equal(...)` was discarded by the rule because `strict` is neither a legacy nor a strict method name. In `explicit` mode this let legacy method calls through such a re-binding escape detection entirely. The destructure path now mirrors the existing import-specifier handling and registers the local name as a strict namespace binding. Regression tests cover both renamed and non-renamed forms, in semantic and explicit modes.
2. **Cover require-strict edge cases comprehensively** — expands the test file from 6 valid + 6 invalid cases to a coverage shape comparable to `no-constant-actual`: namespace imports, bare `assert`/`assert/strict` specifiers, multi-hop const aliases, destructured method bindings (from both base and strict namespaces), template-literal and string-literal computed access, already-strict negatives (let-aliases, unrelated objects, calls before the import, methods outside the legacy mapping), the three-argument form, and additional explicit-mode permutations.
3. **Share assert binding tracker between rules** — generalises `createAssertBindingTracker` over a per-namespace metadata type so `require-strict` no longer needs a parallel binding implementation. The tracker now exposes `classifyModule`, `resolveNamespaceProperty` (for re-exports like Node's `strict` property), the `NOT_ASSERT_MODULE` sentinel, and a `resolveMethodCall` that returns the resolved method together with the namespace metadata. `require-strict` keeps its strict-method early return and stops duplicating the import/destructure/alias walking logic; `no-constant-actual` threads the new shape through unchanged. New tracker tests pin the metadata propagation and the namespace re-export hook.
4. **Cover consistent-import edge cases** — no bug found, but the test file leaves several reachable branches unverified. Adds fixtures across the four recognised module specifiers (`node:assert`, `node:assert/strict`, `assert`, `assert/strict`), the four import shapes (default, namespace, named, side-effect), and the three style options. New cases pin: bare specifiers without the `node:` prefix on the invalid side, `import * as` namespace imports across all styles, `import { strict }` permutations including renamed and combined-with-default forms, named-but-not-`strict` imports under each style, side-effect-only imports, and unrelated module imports as a no-op early return.

Net: `require-strict.ts` shrinks substantially while gaining one bug fix and many new tests; the test suite grows from ~189 cases to 304.