### PR TITLE
Add prefer-match rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ESLint rules for [Node.js assert module](https://nodejs.org/docs/latest/api/asse
 | [consistent-import](docs/rules/consistent-import.md)                       | Enforce a consistent Node.js assert import style                                                    |    |
 | [no-constant-actual](docs/rules/no-constant-actual.md)                     | Disallow passing a constant value as the first argument to Node.js assert methods                   | 🔧 |
 | [no-expected-value-as-message](docs/rules/no-expected-value-as-message.md) | Disallow passing an expected value where a message or error matcher belongs in Node.js assert calls |    |
+| [prefer-match](docs/rules/prefer-match.md)                                 | Prefer assert.match() or assert.doesNotMatch() for regular expression assertions                    | 🔧 |
 | [require-strict](docs/rules/require-strict.md)                             | Require strict assertion semantics for Node.js assert equality methods                              | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/prefer-match.md
+++ b/docs/rules/prefer-match.md
@@ -1,0 +1,33 @@
+# node-assert/prefer-match
+
+📝 Prefer assert.match() or assert.doesNotMatch() for regular expression assertions.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule prefers `assert.match()` and `assert.doesNotMatch()` over wrapping `RegExp#test()` in generic boolean assertions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+assert.ok(/foo/.test(value));
+assert.strictEqual(pattern.test(value), false);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+assert.match(value, /foo/);
+assert.doesNotMatch(value, pattern);
+```
+
+## Fixes
+
+Autofix is intentionally conservative. The rule only rewrites calls when replacing `regex.test(value)` with `match(value, regex)` is unlikely to change evaluation order in a meaningful way and no comments would be lost.

--- a/source/all-rules.ts
+++ b/source/all-rules.ts
@@ -1,12 +1,14 @@
 import { consistentImportRule } from "./rules/consistent-import.js";
 import { noConstantActualRule } from "./rules/no-constant-actual.js";
 import { noExpectedValueAsMessageRule } from "./rules/no-expected-value-as-message.js";
+import { preferMatchRule } from "./rules/prefer-match.js";
 import { requireStrictRule } from "./rules/require-strict.js";
 
 const allRules = {
 	"consistent-import": consistentImportRule,
 	"no-constant-actual": noConstantActualRule,
 	"no-expected-value-as-message": noExpectedValueAsMessageRule,
+	"prefer-match": preferMatchRule,
 	"require-strict": requireStrictRule
 };
 

--- a/source/rules/prefer-match.ts
+++ b/source/rules/prefer-match.ts
@@ -1,0 +1,303 @@
+import { AST_NODE_TYPES, ASTUtils, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../node-assert/method-tracker.js";
+import { isAssertModuleSpecifier } from "../node-assert/modules.js";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
+});
+
+const TARGET_ASSERT_METHOD_NAMES: ReadonlySet<string> = new Set(["ok", "equal", "strictEqual"]);
+const AFFIRMATIVE_ASSERTION_METHOD_NAME = "match";
+const NEGATIVE_ASSERTION_METHOD_NAME = "doesNotMatch";
+const ONE_ASSERTION_ARGUMENT = 1;
+const TWO_ASSERTION_ARGUMENTS = 2;
+
+type MatchedRegularExpressionTest = {
+	readonly regularExpressionExpression: TSESTree.Expression;
+	readonly actualValueExpression: TSESTree.Expression;
+};
+
+type ReplacementPlan = {
+	readonly consumedArgumentCount: typeof ONE_ASSERTION_ARGUMENT | typeof TWO_ASSERTION_ARGUMENTS;
+	readonly replacementMethodName: typeof AFFIRMATIVE_ASSERTION_METHOD_NAME | typeof NEGATIVE_ASSERTION_METHOD_NAME;
+	readonly regularExpressionExpression: TSESTree.Expression;
+	readonly actualValueExpression: TSESTree.Expression;
+};
+
+type BooleanComparison = {
+	readonly firstArgument: TSESTree.Expression;
+	readonly replacementMethodName: typeof AFFIRMATIVE_ASSERTION_METHOD_NAME | typeof NEGATIVE_ASSERTION_METHOD_NAME;
+};
+
+function isTargetAssertMethodName(methodName: string): boolean {
+	return TARGET_ASSERT_METHOD_NAMES.has(methodName);
+}
+
+function getSingleExpressionArgument(
+	callArguments: readonly TSESTree.CallExpressionArgument[]
+): Readonly<TSESTree.Expression> | undefined {
+	const [firstArgument] = callArguments;
+	if (firstArgument === undefined || firstArgument.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return firstArgument;
+}
+
+function getTwoExpressionArguments(
+	callArguments: readonly TSESTree.CallExpressionArgument[]
+): { readonly firstArgument: TSESTree.Expression; readonly secondArgument: TSESTree.Expression } | undefined {
+	const [firstArgument, secondArgument] = callArguments;
+	if (firstArgument === undefined || secondArgument === undefined) {
+		return undefined;
+	}
+	if (firstArgument.type === AST_NODE_TYPES.SpreadElement || secondArgument.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return { firstArgument, secondArgument };
+}
+
+function getBooleanLiteralValue(node: Readonly<TSESTree.Expression>): boolean | undefined {
+	if (node.type !== AST_NODE_TYPES.Literal || typeof node.value !== "boolean") {
+		return undefined;
+	}
+	return node.value;
+}
+
+function getRegularExpressionTestMemberExpression(
+	callExpression: Readonly<TSESTree.CallExpression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- required by getPropertyName
+	scope: TSESLint.Scope.Scope
+): Readonly<TSESTree.MemberExpression> | undefined {
+	const { callee } = callExpression;
+	if (callee.type !== AST_NODE_TYPES.MemberExpression || callee.optional) {
+		return undefined;
+	}
+	if (ASTUtils.getPropertyName(callee, scope) !== "test" || callee.object.type === AST_NODE_TYPES.Super) {
+		return undefined;
+	}
+	return callee;
+}
+
+function getRegularExpressionTestCall(
+	expression: Readonly<TSESTree.Expression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- required by getPropertyName
+	scope: TSESLint.Scope.Scope
+): MatchedRegularExpressionTest | undefined {
+	const callExpression = expression.type === AST_NODE_TYPES.CallExpression ? expression : undefined;
+	if (callExpression === undefined) {
+		return undefined;
+	}
+	const memberExpression = getRegularExpressionTestMemberExpression(callExpression, scope);
+	if (memberExpression === undefined) {
+		return undefined;
+	}
+	const actualValueExpression = getSingleExpressionArgument(callExpression.arguments);
+	if (actualValueExpression === undefined) {
+		return undefined;
+	}
+	return {
+		regularExpressionExpression: memberExpression.object,
+		actualValueExpression
+	};
+}
+
+function getOkReplacementPlan(
+	assertionNode: Readonly<TSESTree.CallExpression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to helper that needs the mutable Scope shape
+	scope: TSESLint.Scope.Scope
+): ReplacementPlan | undefined {
+	const testedExpression = getSingleExpressionArgument(assertionNode.arguments);
+	if (testedExpression === undefined) {
+		return undefined;
+	}
+	const regularExpressionTest = getRegularExpressionTestCall(testedExpression, scope);
+	if (regularExpressionTest === undefined) {
+		return undefined;
+	}
+	return {
+		consumedArgumentCount: ONE_ASSERTION_ARGUMENT,
+		replacementMethodName: AFFIRMATIVE_ASSERTION_METHOD_NAME,
+		...regularExpressionTest
+	};
+}
+
+function getBooleanComparison(
+	callArguments: readonly TSESTree.CallExpressionArgument[]
+): BooleanComparison | undefined {
+	const comparisonArguments = getTwoExpressionArguments(callArguments);
+	if (comparisonArguments === undefined) {
+		return undefined;
+	}
+	const { firstArgument, secondArgument } = comparisonArguments;
+	const expectedBooleanValue = getBooleanLiteralValue(secondArgument);
+	if (expectedBooleanValue === undefined) {
+		return undefined;
+	}
+	return {
+		firstArgument,
+		replacementMethodName: expectedBooleanValue ? AFFIRMATIVE_ASSERTION_METHOD_NAME : NEGATIVE_ASSERTION_METHOD_NAME
+	};
+}
+
+function getEqualityReplacementPlan(
+	assertionNode: Readonly<TSESTree.CallExpression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to helper that needs the mutable Scope shape
+	scope: TSESLint.Scope.Scope
+): ReplacementPlan | undefined {
+	const booleanComparison = getBooleanComparison(assertionNode.arguments);
+	if (booleanComparison === undefined) {
+		return undefined;
+	}
+	const { firstArgument, replacementMethodName } = booleanComparison;
+	const regularExpressionTest = getRegularExpressionTestCall(firstArgument, scope);
+	if (regularExpressionTest === undefined) {
+		return undefined;
+	}
+	return {
+		consumedArgumentCount: TWO_ASSERTION_ARGUMENTS,
+		replacementMethodName,
+		...regularExpressionTest
+	};
+}
+
+function getReplacementPlan(
+	assertMethodName: string,
+	assertionNode: Readonly<TSESTree.CallExpression>,
+	// eslint-disable-next-line functional/prefer-immutable-types -- forwarded to helper that needs the mutable Scope shape
+	scope: TSESLint.Scope.Scope
+): ReplacementPlan | undefined {
+	return assertMethodName === "ok"
+		? getOkReplacementPlan(assertionNode, scope)
+		: getEqualityReplacementPlan(assertionNode, scope);
+}
+
+function isDefinitelySideEffectFreeExpression(expression: Readonly<TSESTree.Expression>): boolean {
+	return (
+		expression.type === AST_NODE_TYPES.Identifier ||
+		expression.type === AST_NODE_TYPES.ThisExpression ||
+		expression.type === AST_NODE_TYPES.Literal
+	);
+}
+
+function hasUnsafeFixingConditions(
+	assertionNode: Readonly<TSESTree.CallExpression>,
+	replacementPlan: Readonly<ReplacementPlan>,
+	sourceCode: Readonly<TSESLint.SourceCode>
+): boolean {
+	if (sourceCode.getCommentsInside(assertionNode).length > 0) {
+		return true;
+	}
+	if (!isDefinitelySideEffectFreeExpression(replacementPlan.regularExpressionExpression)) {
+		return true;
+	}
+	if (!isDefinitelySideEffectFreeExpression(replacementPlan.actualValueExpression)) {
+		return true;
+	}
+	return false;
+}
+
+function getComputedReplacementPropertyText(
+	property: Readonly<TSESTree.Expression>,
+	replacementMethodName: string
+): string | undefined {
+	if (property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
+		return `'${replacementMethodName}'`;
+	}
+	if (property.type === AST_NODE_TYPES.TemplateLiteral && property.expressions.length === 0) {
+		return `\`${replacementMethodName}\``;
+	}
+	return undefined;
+}
+
+function buildReplacementCalleeText(
+	callee: Readonly<TSESTree.Expression>,
+	replacementMethodName: string,
+	sourceCode: Readonly<TSESLint.SourceCode>
+): string | null {
+	if (callee.type !== AST_NODE_TYPES.MemberExpression) {
+		return null;
+	}
+	const objectText = sourceCode.getText(callee.object);
+	if (callee.property.type === AST_NODE_TYPES.Identifier && !callee.computed) {
+		return `${objectText}.${replacementMethodName}`;
+	}
+	if (callee.property.type === AST_NODE_TYPES.PrivateIdentifier) {
+		return null;
+	}
+	const computedPropertyText = getComputedReplacementPropertyText(callee.property, replacementMethodName);
+	return computedPropertyText === undefined ? null : `${objectText}[${computedPropertyText}]`;
+}
+
+function buildReplacementFix(
+	assertionNode: Readonly<TSESTree.CallExpression>,
+	replacementPlan: Readonly<ReplacementPlan>,
+	sourceCode: Readonly<TSESLint.SourceCode>
+): TSESLint.ReportFixFunction | null {
+	const replacementCalleeText = buildReplacementCalleeText(
+		assertionNode.callee,
+		replacementPlan.replacementMethodName,
+		sourceCode
+	);
+	if (replacementCalleeText === null) {
+		return null;
+	}
+	return (fixer) => {
+		const actualValueText = sourceCode.getText(replacementPlan.actualValueExpression);
+		const regularExpressionText = sourceCode.getText(replacementPlan.regularExpressionExpression);
+		const trailingArguments = assertionNode.arguments
+			.slice(replacementPlan.consumedArgumentCount)
+			.map((argumentNode) => {
+				return sourceCode.getText(argumentNode);
+			});
+		const replacementArguments = [actualValueText, regularExpressionText, ...trailingArguments].join(", ");
+		return fixer.replaceText(assertionNode, `${replacementCalleeText}(${replacementArguments})`);
+	};
+}
+
+export const preferMatchRule = createRule({
+	name: "prefer-match",
+	meta: {
+		docs: {
+			description: "Prefer assert.match() or assert.doesNotMatch() for regular expression assertions"
+		},
+		messages: {
+			"prefer-match":
+				"Prefer assert.match() or assert.doesNotMatch() when asserting against a regular expression."
+		},
+		type: "suggestion",
+		fixable: "code",
+		schema: []
+	},
+	defaultOptions: [],
+	create(context) {
+		const tracker = createAssertBindingTracker<null>({
+			isAssertMethod: isTargetAssertMethodName,
+			classifyModule(specifier) {
+				return isAssertModuleSpecifier(specifier) ? null : NOT_ASSERT_MODULE;
+			}
+		});
+		const { sourceCode } = context;
+
+		return {
+			ImportDeclaration: tracker.processImport,
+			VariableDeclaration: tracker.processVariableDeclaration,
+			CallExpression(node) {
+				const scope = sourceCode.getScope(node);
+				const resolvedMethodCall = tracker.resolveMethodCall(node.callee, scope);
+				if (resolvedMethodCall === undefined) {
+					return;
+				}
+				const replacementPlan = getReplacementPlan(resolvedMethodCall.methodName, node, scope);
+				if (replacementPlan === undefined) {
+					return;
+				}
+				const canFix = !hasUnsafeFixingConditions(node, replacementPlan, sourceCode);
+				context.report({
+					messageId: "prefer-match",
+					node,
+					fix: canFix ? buildReplacementFix(node, replacementPlan, sourceCode) : null
+				});
+			}
+		};
+	}
+});

--- a/test/rules/prefer-match.test.ts
+++ b/test/rules/prefer-match.test.ts
@@ -1,0 +1,85 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { preferMatchRule } from "../../source/rules/prefer-match.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-match", preferMatchRule, {
+	valid: [
+		"import assert from 'node:assert/strict'; assert.match(value, /foo/);",
+		"import assert from 'node:assert/strict'; assert.doesNotMatch(value, /foo/);",
+		"import { match } from 'node:assert/strict'; match(value, /foo/);",
+		"import { doesNotMatch } from 'node:assert/strict'; doesNotMatch(value, /foo/);",
+		"import assert from 'node:assert/strict'; assert.ok(predicate(value));",
+		"import assert from 'node:assert/strict'; assert.equal(compare(value), true);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(compare(value), false);",
+		"import assert from 'node:assert/strict'; assert.equal(pattern.test(value), expected);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, true);",
+		"import { ok } from 'somewhere-else'; ok(pattern.test(value));",
+		"const assert = { ok() {} }; assert.ok(pattern.test(value));",
+		"import assert from 'node:assert/strict'; assert.ok(pattern[methodName](value));",
+		"import assert from 'node:assert/strict'; assert.ok(pattern.test(...values));",
+		"import assert from 'node:assert/strict'; assert.equal(pattern.test(value), maybeTrue);"
+	],
+	invalid: [
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(/foo/.test(value));",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.match(value, /foo/);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(pattern.test(value));",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.match(value, pattern);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(pattern.test('value'), 'message');",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.match('value', pattern, 'message');"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal(/foo/.test(value), true);",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.match(value, /foo/);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(pattern.test(value), true, 'message');",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.match(value, pattern, 'message');"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal(/foo/.test(value), false);",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.doesNotMatch(value, /foo/);"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(pattern.test(value), false, 'message');",
+			errors: [{ messageId: "prefer-match" }],
+			output: "import assert from 'node:assert/strict'; assert.doesNotMatch(value, pattern, 'message');"
+		},
+		{
+			code: "import { ok } from 'node:assert/strict'; ok(/foo/.test(value));",
+			errors: [{ messageId: "prefer-match" }],
+			output: null
+		},
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; strictEqual(pattern.test(value), true);",
+			errors: [{ messageId: "prefer-match" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(getPattern().test(value));",
+			errors: [{ messageId: "prefer-match" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(pattern.test(getValue()));",
+			errors: [{ messageId: "prefer-match" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.ok(pattern./* comment */test(value));",
+			errors: [{ messageId: "prefer-match" }],
+			output: null
+		}
+	]
+});


### PR DESCRIPTION
Implement `node-assert/prefer-match` to prefer `assert.match()` and `assert.doesNotMatch()` over boolean assertions around `RegExp#test()`.

Add focused rule coverage for `ok`, `equal`, and `strictEqual`, including conservative autofix behavior that avoids rewrites when comments or likely side effects make the transformation risky.

Fixes #539