### PR TITLE
Enable GitHub merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,10 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+    merge_group:
 
 jobs:
     test:


### PR DESCRIPTION
Run the CI workflow for GitHub merge queue `merge_group` events so queued pull requests receive the same required checks as normal pull requests.

This supports the repository's merge queue ruleset and lets maintainers approve a pull request independently from the final merge step by using "Merge when ready".