### PR TITLE
Add prefer-partial-deep-strict-equal rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ ESLint rules for [Node.js assert module](https://nodejs.org/docs/latest/api/asse
 
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                                       | Description                                                                                         | 🔧 |
-| :------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------- | :- |
-| [consistent-import](docs/rules/consistent-import.md)                       | Enforce a consistent Node.js assert import style                                                    |    |
-| [no-constant-actual](docs/rules/no-constant-actual.md)                     | Disallow passing a constant value as the first argument to Node.js assert methods                   | 🔧 |
-| [no-expected-value-as-message](docs/rules/no-expected-value-as-message.md) | Disallow passing an expected value where a message or error matcher belongs in Node.js assert calls |    |
-| [prefer-match](docs/rules/prefer-match.md)                                 | Prefer assert.match() or assert.doesNotMatch() for regular expression assertions                    | 🔧 |
-| [require-strict](docs/rules/require-strict.md)                             | Require strict assertion semantics for Node.js assert equality methods                              | 🔧 |
+| Name                                                                               | Description                                                                                                             | 🔧 |
+| :--------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :- |
+| [consistent-import](docs/rules/consistent-import.md)                               | Enforce a consistent Node.js assert import style                                                                        |    |
+| [no-constant-actual](docs/rules/no-constant-actual.md)                             | Disallow passing a constant value as the first argument to Node.js assert methods                                       | 🔧 |
+| [no-expected-value-as-message](docs/rules/no-expected-value-as-message.md)         | Disallow passing an expected value where a message or error matcher belongs in Node.js assert calls                     |    |
+| [prefer-match](docs/rules/prefer-match.md)                                         | Prefer assert.match() or assert.doesNotMatch() for regular expression assertions                                        | 🔧 |
+| [prefer-partial-deep-strict-equal](docs/rules/prefer-partial-deep-strict-equal.md) | Prefer a single `partialDeepStrictEqual` over multiple consecutive equality assertions on properties of the same object |    |
+| [require-strict](docs/rules/require-strict.md)                                     | Require strict assertion semantics for Node.js assert equality methods                                                  | 🔧 |
 
 <!-- end auto-generated rules list -->

--- a/docs/rules/prefer-partial-deep-strict-equal.md
+++ b/docs/rules/prefer-partial-deep-strict-equal.md
@@ -1,0 +1,94 @@
+# node-assert/prefer-partial-deep-strict-equal
+
+📝 Prefer a single `partialDeepStrictEqual` over multiple consecutive equality assertions on properties of the same object.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+When several consecutive `assert.strictEqual` (or `assert.deepStrictEqual`) calls each compare a property of the same root object against an expected value, they can usually be expressed as a single `assert.partialDeepStrictEqual` call. The consolidated form keeps related assertions together, removes repetition of the root identifier, and yields a single failure message that mentions every mismatch instead of failing at whichever assertion happens to come first.
+
+This rule reports such runs. It does not autofix because merging into a partial object literal is not always semantically equivalent — see [Caveats](#caveats) — and the developer should review the consolidation manually.
+
+### Reported pattern
+
+```js
+import assert from "node:assert/strict";
+
+assert.strictEqual(user.id, 1);
+assert.strictEqual(user.profile.name, "Alice");
+```
+
+The two calls can be merged into:
+
+```js
+assert.partialDeepStrictEqual(user, {
+    id: 1,
+    profile: {
+        name: "Alice"
+    }
+});
+```
+
+A run is two or more consecutive eligible calls within the same body (a `Program`, `BlockStatement`, `SwitchCase` consequent, or class `static` block). The run is broken by any other statement.
+
+### Eligible calls
+
+A call participates in a run when:
+
+- The method is `strictEqual` or `deepStrictEqual` (resolved through the same binding analysis as the other rules in this plugin: default, named, namespace, renamed, computed, destructured, and `const`-aliased forms).
+- The call is invoked with exactly two arguments. A custom failure message in the third slot disqualifies the call because it cannot be preserved during the merge.
+- The first argument is a `MemberExpression` rooted at a plain `Identifier`, with no computed access anywhere in the chain (so `user.id` and `user.profile.name` are eligible, but `users[0].id`, `user[key]`, `getUser().id`, and `this.user.id` are not).
+- All calls in a run share the same root identifier name. Different roots simply form separate runs.
+
+### Patterns that are not reported
+
+```js
+import assert from "node:assert/strict";
+
+// Single eligible call has nothing to merge.
+assert.strictEqual(user.id, 1);
+
+// Different roots break the run.
+assert.strictEqual(user.id, 1);
+assert.strictEqual(account.balance, 100);
+
+// Methods outside the rule's scope break the run.
+assert.strictEqual(user.id, 1);
+assert.notStrictEqual(user.name, "Alice");
+assert.equal(user.email, "a@b");
+assert.match(user.name, /Alice/);
+
+// A custom failure message would be lost during the merge.
+assert.strictEqual(user.id, 1, "id mismatch");
+assert.strictEqual(user.name, "Alice", "name mismatch");
+
+// Computed access disqualifies the call.
+assert.strictEqual(user[key], 1);
+assert.strictEqual(users[0].id, 1);
+
+// Roots that are not plain identifiers (call expression, `this`, etc.) are skipped.
+assert.strictEqual(getUser().id, 1);
+assert.strictEqual(this.user.id, 1);
+
+// Statements between the calls break the run.
+assert.strictEqual(user.id, 1);
+console.log("between");
+assert.strictEqual(user.name, "Alice");
+```
+
+### Caveats
+
+`assert.strictEqual` performs strict equality at the leaf, while `assert.partialDeepStrictEqual` performs deep equality on every property in the expected object. For primitive expected values (numbers, strings, booleans, `null`, `undefined`, regular expressions compared by reference, and similar) the two are interchangeable. When the expected value is an object reference, the merged form will compare the contents of that object instead of the identity, which can change the meaning of the assertion. Review the merge before applying it.
+
+### Recognized usage patterns
+
+The rule resolves common indirections on top of plain `assert.method(...)` calls:
+
+- ESM imports from `node:assert`, `node:assert/strict`, `assert`, and `assert/strict`.
+- Aliased and namespace imports.
+- Re-exported strict namespaces (`import { strict } from 'node:assert'; strict.strictEqual(...)`), including the `const`-destructuring form.
+- Computed member access with a string literal, constant template literal, or `const`-declared string key.
+- `const` aliases of namespaces (multi-hop chains included) and destructured method bindings.
+
+`let`-declared aliases are intentionally not tracked because the binding could be reassigned. CommonJS `require` is not tracked.

--- a/source/all-rules.ts
+++ b/source/all-rules.ts
@@ -2,6 +2,7 @@ import { consistentImportRule } from "./rules/consistent-import.js";
 import { noConstantActualRule } from "./rules/no-constant-actual.js";
 import { noExpectedValueAsMessageRule } from "./rules/no-expected-value-as-message.js";
 import { preferMatchRule } from "./rules/prefer-match.js";
+import { preferPartialDeepStrictEqualRule } from "./rules/prefer-partial-deep-strict-equal.js";
 import { requireStrictRule } from "./rules/require-strict.js";
 
 const allRules = {
@@ -9,6 +10,7 @@ const allRules = {
 	"no-constant-actual": noConstantActualRule,
 	"no-expected-value-as-message": noExpectedValueAsMessageRule,
 	"prefer-match": preferMatchRule,
+	"prefer-partial-deep-strict-equal": preferPartialDeepStrictEqualRule,
 	"require-strict": requireStrictRule
 };
 

--- a/source/rules/prefer-partial-deep-strict-equal.ts
+++ b/source/rules/prefer-partial-deep-strict-equal.ts
@@ -1,0 +1,191 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESTree } from "@typescript-eslint/utils";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../node-assert/method-tracker.js";
+import { isAssertModuleSpecifier } from "../node-assert/modules.js";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
+});
+
+const ELIGIBLE_METHODS: ReadonlySet<string> = new Set(["strictEqual", "deepStrictEqual"]);
+
+const ARGS_WITHOUT_MESSAGE = 2;
+const MIN_RUN_LENGTH = 2;
+
+type RunCandidate = {
+	readonly rootName: string;
+	readonly call: Readonly<TSESTree.CallExpression>;
+};
+
+function isAssertMethodName(name: string): boolean {
+	return ELIGIBLE_METHODS.has(name);
+}
+
+function resolveStrictReExport(propertyName: string): null | undefined {
+	return propertyName === "strict" ? null : undefined;
+}
+
+function getMemberRoot(expression: Readonly<TSESTree.Expression>): Readonly<TSESTree.Identifier> | undefined {
+	if (expression.type !== AST_NODE_TYPES.MemberExpression || expression.computed) {
+		return undefined;
+	}
+	const { object } = expression;
+	if (object.type === AST_NODE_TYPES.Identifier) {
+		return object;
+	}
+	if (object.type === AST_NODE_TYPES.MemberExpression) {
+		return getMemberRoot(object);
+	}
+	return undefined;
+}
+
+function getEligibleCallExpression(node: Readonly<TSESTree.Node>): Readonly<TSESTree.CallExpression> | undefined {
+	if (node.type !== AST_NODE_TYPES.ExpressionStatement) {
+		return undefined;
+	}
+	if (node.expression.type !== AST_NODE_TYPES.CallExpression) {
+		return undefined;
+	}
+	return node.expression;
+}
+
+function isPlainMemberExpression(
+	argument: Readonly<TSESTree.CallExpressionArgument>
+): argument is Readonly<TSESTree.MemberExpression> {
+	return argument.type === AST_NODE_TYPES.MemberExpression && !argument.computed;
+}
+
+function getActualMemberExpression(
+	call: Readonly<TSESTree.CallExpression>
+): Readonly<TSESTree.MemberExpression> | undefined {
+	if (call.arguments.length !== ARGS_WITHOUT_MESSAGE) {
+		return undefined;
+	}
+	const [actual, expected] = call.arguments;
+	if (actual === undefined || expected === undefined) {
+		return undefined;
+	}
+	if (expected.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return isPlainMemberExpression(actual) ? actual : undefined;
+}
+
+function shouldBreakRun(current: readonly RunCandidate[], candidate: RunCandidate | undefined): boolean {
+	if (candidate === undefined) {
+		return true;
+	}
+	const head = current[0];
+	return head !== undefined && head.rootName !== candidate.rootName;
+}
+
+/* eslint-disable max-statements -- the grouping reducer reads more clearly as a single pass than artificially split */
+function groupConsecutiveCandidates(
+	candidates: readonly (RunCandidate | undefined)[]
+): readonly (readonly RunCandidate[])[] {
+	const groups: RunCandidate[][] = [];
+	let current: RunCandidate[] = [];
+	for (const candidate of candidates) {
+		if (shouldBreakRun(current, candidate)) {
+			if (current.length > 0) {
+				groups.push(current);
+			}
+			current = [];
+		}
+		if (candidate !== undefined) {
+			current.push(candidate);
+		}
+	}
+	if (current.length > 0) {
+		groups.push(current);
+	}
+	return groups;
+}
+/* eslint-enable max-statements -- re-enable for the rest of the file */
+
+export const preferPartialDeepStrictEqualRule = createRule({
+	name: "prefer-partial-deep-strict-equal",
+	meta: {
+		docs: {
+			description:
+				// eslint-disable-next-line @stylistic/max-len -- the description renders as a single sentence in the generated rules table
+				"Prefer a single `partialDeepStrictEqual` over multiple consecutive equality assertions on properties of the same object"
+		},
+		messages: {
+			"prefer-partial-deep-strict-equal":
+				"Multiple consecutive equality assertions on properties of '{{rootName}}' can be combined " +
+				"into a single 'partialDeepStrictEqual' call"
+		},
+		type: "suggestion",
+		schema: []
+	},
+	defaultOptions: [],
+
+	create(context) {
+		const tracker = createAssertBindingTracker<null>({
+			isAssertMethod: isAssertMethodName,
+			classifyModule(specifier) {
+				return isAssertModuleSpecifier(specifier) ? null : NOT_ASSERT_MODULE;
+			},
+			resolveNamespaceProperty: resolveStrictReExport
+		});
+		const { sourceCode } = context;
+
+		function resolveCandidate(call: Readonly<TSESTree.CallExpression>, rootName: string): RunCandidate | undefined {
+			const resolved = tracker.resolveMethodCall(call.callee, sourceCode.getScope(call));
+			if (resolved === undefined || !ELIGIBLE_METHODS.has(resolved.methodName)) {
+				return undefined;
+			}
+			return { rootName, call };
+		}
+
+		function classifyNode(node: Readonly<TSESTree.Node>): RunCandidate | undefined {
+			const call = getEligibleCallExpression(node);
+			if (call === undefined) {
+				return undefined;
+			}
+			const actual = getActualMemberExpression(call);
+			const root = actual === undefined ? undefined : getMemberRoot(actual);
+			if (root === undefined) {
+				return undefined;
+			}
+			return resolveCandidate(call, root.name);
+		}
+
+		function reportRun(group: readonly RunCandidate[]): void {
+			const head = group[0];
+			if (head === undefined || group.length < MIN_RUN_LENGTH) {
+				return;
+			}
+			context.report({
+				messageId: "prefer-partial-deep-strict-equal",
+				node: head.call,
+				data: { rootName: head.rootName }
+			});
+		}
+
+		function visitNodeList(nodes: readonly Readonly<TSESTree.Node>[]): void {
+			const candidates = nodes.map(classifyNode);
+			const groups = groupConsecutiveCandidates(candidates);
+			for (const group of groups) {
+				reportRun(group);
+			}
+		}
+
+		return {
+			ImportDeclaration: tracker.processImport,
+			VariableDeclaration: tracker.processVariableDeclaration,
+			"Program:exit"(node) {
+				visitNodeList(node.body);
+			},
+			"BlockStatement:exit"(node) {
+				visitNodeList(node.body);
+			},
+			"SwitchCase:exit"(node) {
+				visitNodeList(node.consequent);
+			},
+			"StaticBlock:exit"(node) {
+				visitNodeList(node.body);
+			}
+		};
+	}
+});

--- a/test/rules/prefer-partial-deep-strict-equal.test.ts
+++ b/test/rules/prefer-partial-deep-strict-equal.test.ts
@@ -1,0 +1,294 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { preferPartialDeepStrictEqualRule } from "../../source/rules/prefer-partial-deep-strict-equal.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-partial-deep-strict-equal", preferPartialDeepStrictEqualRule, {
+	valid: [
+		// Single eligible call cannot be merged
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1);",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual(user.profile, {});",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.profile.name, 'Alice');",
+
+		// Two adjacent calls on different roots
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(account.balance, 100);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(a.x, 1); assert.strictEqual(b.y, 2); assert.strictEqual(c.z, 3);",
+
+		// Non-eligible methods break the run
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.notStrictEqual(user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.notDeepStrictEqual(user.profile, {});",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.equal(user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.deepEqual(user.profile, {});",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.match(user.name, /Alice/);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.doesNotMatch(user.name, /Alice/);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.ok(user.active);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.partialDeepStrictEqual(user, {});",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.throws(() => user.fail(), Error);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.ifError(user.error);",
+
+		// Actual is not a member expression
+		"import assert from 'node:assert/strict'; assert.strictEqual(user, 1); assert.strictEqual(user, 2);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(value, 1); assert.strictEqual(other, 2);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(getUser(), 1); assert.strictEqual(getUser(), 2);",
+
+		// Computed access anywhere in the actual chain
+		"import assert from 'node:assert/strict'; assert.strictEqual(user[key], 1); assert.strictEqual(user[other], 2);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(users[0].id, 1); assert.strictEqual(users[0].name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.profile['name'], 'Alice'); assert.strictEqual(user.profile['email'], 'a@b');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user[`id`], 1); assert.strictEqual(user[`name`], 'Alice');",
+
+		// Actual rooted at a non-Identifier expression
+		"import assert from 'node:assert/strict'; assert.strictEqual(getUser().id, 1); assert.strictEqual(getUser().name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(this.user.id, 1); assert.strictEqual(this.user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual((user || other).id, 1); assert.strictEqual((user || other).name, 'Alice');",
+
+		// Three-argument form with custom message would lose the message when merged
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1, 'id'); assert.strictEqual(user.name, 'Alice', 'name');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice', 'name');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1, 'id'); assert.strictEqual(user.name, 'Alice');",
+
+		// Spread arguments are opaque
+		"import assert from 'node:assert/strict'; assert.strictEqual(...args); assert.strictEqual(user.id, 1);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(...args);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, ...rest);",
+
+		// Run interrupted by an unrelated statement
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); console.log('between'); assert.strictEqual(user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); const x = 1; assert.strictEqual(user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); if (cond) {} assert.strictEqual(user.name, 'Alice');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); ; assert.strictEqual(user.name, 'Alice');",
+
+		// Awaited calls do not appear as direct CallExpressions
+		"import assert from 'node:assert/strict'; async function test() { await assert.strictEqual(user.id, 1); await assert.strictEqual(user.name, 'Alice'); }",
+
+		// Two calls in different sibling blocks
+		"import assert from 'node:assert/strict'; if (cond) { assert.strictEqual(user.id, 1); } else { assert.strictEqual(user.name, 'Alice'); }",
+		"import assert from 'node:assert/strict'; { assert.strictEqual(user.id, 1); } { assert.strictEqual(user.name, 'Alice'); }",
+
+		// Imports from unrelated modules are ignored
+		"import { strictEqual } from 'somewhere-else'; strictEqual(user.id, 1); strictEqual(user.name, 'Alice');",
+		"import assert from 'somewhere-else'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+
+		// CommonJS require is intentionally not tracked
+		"const assert = require('node:assert/strict'); assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+		"const { strictEqual } = require('node:assert/strict'); strictEqual(user.id, 1); strictEqual(user.name, 'Alice');",
+
+		// let-declared aliases are not propagated
+		"import assert from 'node:assert/strict'; let a = assert; a.strictEqual(user.id, 1); a.strictEqual(user.name, 'Alice');",
+		"import { strictEqual } from 'node:assert/strict'; let eq = strictEqual; eq(user.id, 1); eq(user.name, 'Alice');",
+
+		// Member call on an unrelated object
+		"const other = { strictEqual: () => {} }; other.strictEqual(user.id, 1); other.strictEqual(user.name, 'Alice');",
+
+		// Computed property name on assert that cannot be statically resolved
+		"import assert from 'node:assert/strict'; assert[someKey](user.id, 1); assert[someKey](user.name, 'Alice');",
+
+		// Namespace-callable form is not tracked by this rule
+		"import assert from 'node:assert/strict'; assert(user.id, 1); assert(user.name, 'Alice');",
+
+		// Mixed runs where each run is below the threshold
+		"import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(account.balance, 100); assert.strictEqual(other.x, 1);",
+
+		// Two calls separated by a switch fall-through (different SwitchCase consequents)
+		"import assert from 'node:assert/strict'; switch (x) { case 1: assert.strictEqual(user.id, 1); break; case 2: assert.strictEqual(user.name, 'Alice'); break; }"
+	],
+	invalid: [
+		// Two adjacent strictEqual calls on the same simple root
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Deep property paths on the same root
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.profile.name, 'Alice'); assert.strictEqual(user.profile.email, 'a@b');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Three adjacent calls report a single violation at the head of the run
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); assert.strictEqual(user.email, 'a@b');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Mixed eligible methods on the same root
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.deepStrictEqual(user.profile, { name: 'Alice' });",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Two deepStrictEqual calls on the same root
+		{
+			code: "import assert from 'node:assert/strict'; assert.deepStrictEqual(user.profile, { name: 'Alice' }); assert.deepStrictEqual(user.address, { city: 'X' });",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Same property path twice still constitutes a run on the same root
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.id, 2);",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Namespace import binding
+		{
+			code: "import * as assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Named import (no alias)
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; strictEqual(user.id, 1); strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Aliased named import
+		{
+			code: "import { strictEqual as eq } from 'node:assert/strict'; eq(user.id, 1); eq(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Mixed direct and named imports
+		{
+			code: "import assert, { deepStrictEqual } from 'node:assert/strict'; assert.strictEqual(user.id, 1); deepStrictEqual(user.profile, {});",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Base specifier (`node:assert`)
+		{
+			code: "import assert from 'node:assert'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Bare specifiers without the node: protocol
+		{
+			code: "import assert from 'assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		{
+			code: "import assert from 'assert'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		{
+			code: "import { strictEqual } from 'assert/strict'; strictEqual(user.id, 1); strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// strict re-export through a named import
+		{
+			code: "import { strict } from 'node:assert'; strict.strictEqual(user.id, 1); strict.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// strict re-export through a renamed named import
+		{
+			code: "import { strict as s } from 'node:assert'; s.strictEqual(user.id, 1); s.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// strict re-export through const destructuring
+		{
+			code: "import assert from 'node:assert'; const { strict } = assert; strict.strictEqual(user.id, 1); strict.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// strict re-export through renamed const destructuring
+		{
+			code: "import assert from 'node:assert'; const { strict: s } = assert; s.strictEqual(user.id, 1); s.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// const namespace alias
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; a.strictEqual(user.id, 1); a.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Multi-hop alias
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; const b = a; b.strictEqual(user.id, 1); b.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Destructured method
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(user.id, 1); strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Renamed destructured method
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual: eq } = assert; eq(user.id, 1); eq(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Re-binding a named import
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(user.id, 1); eq(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Computed member access (literal, template, const-bound)
+		{
+			code: "import assert from 'node:assert/strict'; assert['strictEqual'](user.id, 1); assert['strictEqual'](user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert[`strictEqual`](user.id, 1); assert[`strictEqual`](user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const key = 'strictEqual'; assert[key](user.id, 1); assert[key](user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Mixed bindings resolving to the same method on the same root
+		{
+			code: "import assert from 'node:assert/strict'; const a = assert; const b = assert; a.strictEqual(user.id, 1); b.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Two separate runs in the same file produce two reports
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); const sep = 1; assert.strictEqual(account.balance, 100); assert.strictEqual(account.owner, 'Bob');",
+			errors: [
+				{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } },
+				{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "account" } }
+			]
+		},
+		// Adjacent runs with different roots produce one report per run of two-or-more
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); assert.strictEqual(account.balance, 100); assert.strictEqual(account.owner, 'Bob');",
+			errors: [
+				{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } },
+				{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "account" } }
+			]
+		},
+		// Mixed run: only the matching adjacent pair is reported
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.id, 1); assert.strictEqual(account.balance, 100); assert.strictEqual(account.owner, 'Bob');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "account" } }]
+		},
+		// Inside a function body
+		{
+			code: "import assert from 'node:assert/strict'; function test() { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); }",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Inside an arrow function body
+		{
+			code: "import assert from 'node:assert/strict'; const test = () => { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); };",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Inside an `if` block
+		{
+			code: "import assert from 'node:assert/strict'; if (cond) { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); }",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Inside a try block
+		{
+			code: "import assert from 'node:assert/strict'; try { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); } catch (error) {}",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Inside a switch case consequent
+		{
+			code: "import assert from 'node:assert/strict'; switch (x) { case 1: assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); break; }",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Inside a class static block
+		{
+			code: "import assert from 'node:assert/strict'; class C { static { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); } }",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Run preceded by a non-eligible call still triggers
+		{
+			code: "import assert from 'node:assert/strict'; console.log('start'); assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice');",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Run with deeper nested property paths (root identifier shared)
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(user.profile.name, 'Alice'); assert.strictEqual(user.id, 1); assert.deepStrictEqual(user.address, {});",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		},
+		// Run inside a nested function inside a block
+		{
+			code: "import assert from 'node:assert/strict'; if (cond) { function inner() { assert.strictEqual(user.id, 1); assert.strictEqual(user.name, 'Alice'); } }",
+			errors: [{ messageId: "prefer-partial-deep-strict-equal", data: { rootName: "user" } }]
+		}
+	]
+});


### PR DESCRIPTION
Resolves #550. Detects runs of two or more consecutive `assert.strictEqual` or `assert.deepStrictEqual` calls whose first argument is a non-computed property chain rooted at the same identifier, and suggests consolidating them into a single `assert.partialDeepStrictEqual` call.

The rule reuses the shared assert binding tracker, so it recognises every binding shape the other rules already handle (default/named/namespace imports, aliased and renamed bindings, destructured methods, multi-hop const aliases, computed access with statically resolvable keys, strict re-exports both as named imports and through const destructuring, and bare specifiers without the `node:` protocol). Run analysis runs at container exit (Program, BlockStatement, SwitchCase, StaticBlock) so a run is broken by any non-eligible statement between calls.

Calls with a custom failure message in the third slot, computed property access anywhere in the actual chain, and roots that are not plain identifiers (call expressions, `this`, parenthesised expressions, …) are intentionally excluded — the merge cannot preserve the message and the shape of the partial object literal is ambiguous in the other cases.

No autofix: `strictEqual` is reference equality at the leaf while `partialDeepStrictEqual` does deep equality on every expected property, so merging is not always semantics-preserving when the expected value is an object reference. The doc calls this caveat out explicitly.