### PR TITLE
Add prefer-deep-equality rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ ESLint rules for [Node.js assert module](https://nodejs.org/docs/latest/api/asse
 | [consistent-import](docs/rules/consistent-import.md)                               | Enforce a consistent Node.js assert import style                                                                        |    |
 | [no-constant-actual](docs/rules/no-constant-actual.md)                             | Disallow passing a constant value as the first argument to Node.js assert methods                                       | 🔧 |
 | [no-expected-value-as-message](docs/rules/no-expected-value-as-message.md)         | Disallow passing an expected value where a message or error matcher belongs in Node.js assert calls                     |    |
+| [prefer-deep-equality](docs/rules/prefer-deep-equality.md)                         | Prefer deep equality assertions when comparing object or array literals                                                 | 🔧 |
 | [prefer-match](docs/rules/prefer-match.md)                                         | Prefer assert.match() or assert.doesNotMatch() for regular expression assertions                                        | 🔧 |
 | [prefer-partial-deep-strict-equal](docs/rules/prefer-partial-deep-strict-equal.md) | Prefer a single `partialDeepStrictEqual` over multiple consecutive equality assertions on properties of the same object |    |
 | [require-strict](docs/rules/require-strict.md)                                     | Require strict assertion semantics for Node.js assert equality methods                                                  | 🔧 |

--- a/docs/rules/prefer-deep-equality.md
+++ b/docs/rules/prefer-deep-equality.md
@@ -1,0 +1,74 @@
+# node-assert/prefer-deep-equality
+
+📝 Prefer deep equality assertions when comparing object or array literals.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+`assert.strictEqual` and `assert.equal` compare their arguments with reference equality semantics for objects. When the expected (or actual) value is an object literal, an array literal, or any freshly allocated structure, that comparison can never be true unless one side is the very same reference. The intended check is a structural one, which is what `assert.deepStrictEqual` and `assert.deepEqual` provide.
+
+This rule reports `assert.strictEqual` and `assert.equal` calls where at least one of the two compared arguments is an object or array literal, and rewrites them to the corresponding deep variant:
+
+- `strictEqual` → `deepStrictEqual`
+- `equal` → `deepEqual`
+
+Examples of **incorrect** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+assert.strictEqual(result, { ok: true });
+assert.strictEqual(result, [1, 2, 3]);
+assert.equal(result, { ok: true });
+assert.strictEqual({ ok: true }, result);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+import assert from "node:assert/strict";
+
+assert.deepStrictEqual(result, { ok: true });
+assert.deepStrictEqual(result, [1, 2, 3]);
+assert.deepEqual(result, { ok: true });
+assert.strictEqual(result, 42);
+assert.strictEqual(result, "hello");
+assert.strictEqual(result, null);
+```
+
+### Detection
+
+A call is reported when:
+
+- The resolved method is `strictEqual` or `equal` on a binding originating from `node:assert`, `node:assert/strict`, `assert`, or `assert/strict` (resolved through the same binding analysis as the other rules in this plugin: default, named, namespace, renamed, computed, destructured, and `const`-aliased forms).
+- The call has at least two arguments and neither of the first two is a `SpreadElement`.
+- At least one of the first two arguments is an `ObjectExpression` (`{ ... }`) or `ArrayExpression` (`[ ... ]`).
+
+The rule deliberately limits detection to literal forms because, without type information, an arbitrary expression cannot be classified as an object reference. If you compare a value that is *known* to be an object but not written as a literal (for example, a result returned from a factory), the rule will not flag it. Use `deepStrictEqual` or `deepEqual` whenever in doubt.
+
+### Autofix
+
+The fix replaces the called method name with the deep variant. The remaining arguments — including a custom failure message in the third slot — are preserved verbatim.
+
+The autofix is applied for the common shapes of the callee:
+
+- `assert.strictEqual(...)` (member access via identifier)
+- `assert['strictEqual'](...)` (computed access with a string literal)
+- `` assert[`strictEqual`](...) `` (computed access with a constant template literal)
+
+Identifier callees (e.g. a named import like `import { strictEqual } from 'node:assert'; strictEqual(actual, {})`) are reported but not autofixed, because rewriting the call site would also require changing the import. Computed access via a `const`-bound key (`const k = 'strictEqual'; assert[k](...)`) is reported but not autofixed for the same reason.
+
+### Recognized usage patterns
+
+The rule resolves common indirections on top of plain `assert.method(...)` calls:
+
+- ESM imports from `node:assert`, `node:assert/strict`, `assert`, and `assert/strict`.
+- Aliased and namespace imports.
+- Re-exported strict namespaces (`import { strict } from 'node:assert'; strict.strictEqual(...)`), including the `const`-destructuring form.
+- Computed member access with a string literal, constant template literal, or `const`-declared string key.
+- `const` aliases of namespaces (multi-hop chains included) and destructured method bindings.
+
+`let`-declared aliases are intentionally not tracked because the binding could be reassigned. CommonJS `require` is not tracked.

--- a/source/all-rules.ts
+++ b/source/all-rules.ts
@@ -1,6 +1,7 @@
 import { consistentImportRule } from "./rules/consistent-import.js";
 import { noConstantActualRule } from "./rules/no-constant-actual.js";
 import { noExpectedValueAsMessageRule } from "./rules/no-expected-value-as-message.js";
+import { preferDeepEqualityRule } from "./rules/prefer-deep-equality.js";
 import { preferMatchRule } from "./rules/prefer-match.js";
 import { preferPartialDeepStrictEqualRule } from "./rules/prefer-partial-deep-strict-equal.js";
 import { requireStrictRule } from "./rules/require-strict.js";
@@ -9,6 +10,7 @@ const allRules = {
 	"consistent-import": consistentImportRule,
 	"no-constant-actual": noConstantActualRule,
 	"no-expected-value-as-message": noExpectedValueAsMessageRule,
+	"prefer-deep-equality": preferDeepEqualityRule,
 	"prefer-match": preferMatchRule,
 	"prefer-partial-deep-strict-equal": preferPartialDeepStrictEqualRule,
 	"require-strict": requireStrictRule

--- a/source/rules/prefer-deep-equality.ts
+++ b/source/rules/prefer-deep-equality.ts
@@ -1,0 +1,146 @@
+import { AST_NODE_TYPES, ESLintUtils, type TSESLint, type TSESTree } from "@typescript-eslint/utils";
+import { createAssertBindingTracker, NOT_ASSERT_MODULE } from "../node-assert/method-tracker.js";
+import { isAssertModuleSpecifier } from "../node-assert/modules.js";
+
+const createRule = ESLintUtils.RuleCreator((name) => {
+	return `https://github.com/screendriver/eslint-plugin-node-assert/blob/master/docs/rules/${name}.md`;
+});
+
+const SHALLOW_TO_DEEP_METHOD_NAME = new Map<string, string>([
+	["strictEqual", "deepStrictEqual"],
+	["equal", "deepEqual"]
+]);
+
+const TWO_ARGUMENTS = 2;
+
+type EqualityArguments = {
+	readonly actualArg: TSESTree.Expression;
+	readonly expectedArg: TSESTree.Expression;
+};
+
+function isAssertMethodName(name: string): boolean {
+	return SHALLOW_TO_DEEP_METHOD_NAME.has(name);
+}
+
+function resolveStrictReExport(propertyName: string): null | undefined {
+	return propertyName === "strict" ? null : undefined;
+}
+
+function getEqualityArguments(args: readonly TSESTree.CallExpressionArgument[]): EqualityArguments | undefined {
+	if (args.length < TWO_ARGUMENTS) {
+		return undefined;
+	}
+	const [actualArg, expectedArg] = args;
+	if (actualArg === undefined || expectedArg === undefined) {
+		return undefined;
+	}
+	if (actualArg.type === AST_NODE_TYPES.SpreadElement || expectedArg.type === AST_NODE_TYPES.SpreadElement) {
+		return undefined;
+	}
+	return { actualArg, expectedArg };
+}
+
+function isObjectOrArrayLiteral(node: Readonly<TSESTree.Node>): boolean {
+	return node.type === AST_NODE_TYPES.ObjectExpression || node.type === AST_NODE_TYPES.ArrayExpression;
+}
+
+/* eslint-disable complexity -- explicit guarded branches per autofix shape make this clearer than splitting */
+function buildPropertyReplacementFix(
+	callee: Readonly<TSESTree.MemberExpression>,
+	deepMethodName: string
+): TSESLint.ReportFixFunction | null {
+	const { property } = callee;
+	if (property.type === AST_NODE_TYPES.Identifier && !callee.computed) {
+		return (fixer) => {
+			return fixer.replaceText(property, deepMethodName);
+		};
+	}
+	if (property.type === AST_NODE_TYPES.Literal && typeof property.value === "string") {
+		return (fixer) => {
+			return fixer.replaceText(property, `'${deepMethodName}'`);
+		};
+	}
+	if (property.type === AST_NODE_TYPES.TemplateLiteral && property.expressions.length === 0) {
+		return (fixer) => {
+			return fixer.replaceText(property, `\`${deepMethodName}\``);
+		};
+	}
+	return null;
+}
+/* eslint-enable complexity -- re-enable for the rest of the file */
+
+function buildFix(callee: Readonly<TSESTree.Expression>, deepMethodName: string): TSESLint.ReportFixFunction | null {
+	if (callee.type !== AST_NODE_TYPES.MemberExpression) {
+		return null;
+	}
+	return buildPropertyReplacementFix(callee, deepMethodName);
+}
+
+export const preferDeepEqualityRule = createRule({
+	name: "prefer-deep-equality",
+	meta: {
+		docs: {
+			description: "Prefer deep equality assertions when comparing object or array literals"
+		},
+		messages: {
+			"prefer-deep-equality":
+				"Use '{{deepMethodName}}' instead of '{{shallowMethodName}}' when comparing object or array literals"
+		},
+		type: "problem",
+		fixable: "code",
+		schema: []
+	},
+	defaultOptions: [],
+	create(context) {
+		const tracker = createAssertBindingTracker<null>({
+			isAssertMethod: isAssertMethodName,
+			classifyModule(specifier) {
+				return isAssertModuleSpecifier(specifier) ? null : NOT_ASSERT_MODULE;
+			},
+			resolveNamespaceProperty: resolveStrictReExport
+		});
+		const { sourceCode } = context;
+
+		function reportShallowEquality(
+			node: Readonly<TSESTree.CallExpression>,
+			shallowMethodName: string,
+			deepMethodName: string
+		): void {
+			context.report({
+				messageId: "prefer-deep-equality",
+				node,
+				data: { shallowMethodName, deepMethodName },
+				fix: buildFix(node.callee, deepMethodName)
+			});
+		}
+
+		function comparesObjectOrArrayLiteral(node: Readonly<TSESTree.CallExpression>): boolean {
+			const equality = getEqualityArguments(node.arguments);
+			if (equality === undefined) {
+				return false;
+			}
+			return isObjectOrArrayLiteral(equality.actualArg) || isObjectOrArrayLiteral(equality.expectedArg);
+		}
+
+		function handleCall(node: Readonly<TSESTree.CallExpression>): void {
+			const resolved = tracker.resolveMethodCall(node.callee, sourceCode.getScope(node));
+			if (resolved === undefined) {
+				return;
+			}
+			const deepMethodName = SHALLOW_TO_DEEP_METHOD_NAME.get(resolved.methodName);
+			if (deepMethodName === undefined) {
+				return;
+			}
+			if (!comparesObjectOrArrayLiteral(node)) {
+				return;
+			}
+			reportShallowEquality(node, resolved.methodName, deepMethodName);
+		}
+
+		return {
+			ImportDeclaration: tracker.processImport,
+			VariableDeclaration: tracker.processVariableDeclaration,
+			CallExpression: handleCall
+		};
+	}
+});

--- a/test/rules/prefer-deep-equality.test.ts
+++ b/test/rules/prefer-deep-equality.test.ts
@@ -1,0 +1,397 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import { preferDeepEqualityRule } from "../../source/rules/prefer-deep-equality.js";
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("prefer-deep-equality", preferDeepEqualityRule, {
+	valid: [
+		// Already-deep methods are fine
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.deepEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.deepStrictEqual(result, [1, 2, 3]);",
+		"import assert from 'node:assert/strict'; assert.notDeepStrictEqual(result, {});",
+		"import assert from 'node:assert/strict'; assert.notDeepEqual(result, {});",
+
+		// Both sides are primitives — strictEqual is appropriate
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, 42);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, 'hello');",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, true);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, null);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, undefined);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, NaN);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, Infinity);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, -1);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, /foo/);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, `hello`);",
+		"import assert from 'node:assert/strict'; assert.equal(result, 42);",
+		"import assert from 'node:assert/strict'; assert.equal(result, 'hello');",
+
+		// Identifiers on both sides — opaque, not flagged
+		"import assert from 'node:assert/strict'; assert.strictEqual(actual, expected);",
+		"import assert from 'node:assert/strict'; assert.equal(actual, expected);",
+
+		// Method/constructor calls produce values but their shape is unknown
+		"import assert from 'node:assert/strict'; assert.strictEqual(getResult(), getExpected());",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, new Map());",
+		"import assert from 'node:assert/strict'; assert.strictEqual(result, new Set());",
+
+		// Methods outside the rule's scope are ignored, even with literals
+		"import assert from 'node:assert/strict'; assert.notStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.notEqual(result, [1, 2, 3]);",
+		"import assert from 'node:assert/strict'; assert.ok({ ok: true });",
+		"import assert from 'node:assert/strict'; assert.match(result, /foo/);",
+		"import assert from 'node:assert/strict'; assert.throws(() => fn(), { message: 'x' });",
+		"import assert from 'node:assert/strict'; assert.partialDeepStrictEqual(result, { ok: true });",
+		"import assert from 'node:assert/strict'; assert.ifError({ ok: true });",
+
+		// Imports from unrelated modules are ignored
+		"import assert from 'somewhere-else'; assert.strictEqual(result, { ok: true });",
+		"import { strictEqual } from 'somewhere-else'; strictEqual(result, { ok: true });",
+
+		// Calls on unrelated objects must not be tracked
+		"const other = { strictEqual: () => {} }; other.strictEqual(result, { ok: true });",
+		"const assert = { strictEqual() {} }; assert.strictEqual(result, { ok: true });",
+
+		// CommonJS require is intentionally not tracked
+		"const assert = require('node:assert/strict'); assert.strictEqual(result, { ok: true });",
+		"const { strictEqual } = require('node:assert/strict'); strictEqual(result, { ok: true });",
+
+		// `let`-declared aliases are not propagated
+		"import assert from 'node:assert/strict'; let a = assert; a.strictEqual(result, { ok: true });",
+		"import { strictEqual } from 'node:assert/strict'; let eq = strictEqual; eq(result, { ok: true });",
+
+		// Computed access with a non-resolvable key
+		"import assert from 'node:assert/strict'; assert[someKey](result, { ok: true });",
+
+		// Arguments below the equality arity
+		"import assert from 'node:assert/strict'; assert.strictEqual({ ok: true });",
+		"import assert from 'node:assert/strict'; assert.strictEqual();",
+
+		// Spread arguments are opaque
+		"import assert from 'node:assert/strict'; assert.strictEqual(...args);",
+		"import assert from 'node:assert/strict'; assert.strictEqual({ ok: true }, ...rest);",
+		"import assert from 'node:assert/strict'; assert.strictEqual(...rest, { ok: true });",
+
+		// Side-effect-only import: no specifiers, no crash
+		"import 'node:assert';",
+		"import 'node:assert/strict';",
+
+		// Calls before the import declaration cannot resolve a binding
+		"strictEqual(other, { ok: true }); import { strictEqual } from 'node:assert/strict';"
+	],
+	invalid: [
+		// Object literal as expected (the canonical case from the issue)
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, { ok: true });",
+			errors: [
+				{
+					messageId: "prefer-deep-equality",
+					data: { shallowMethodName: "strictEqual", deepMethodName: "deepStrictEqual" }
+				}
+			],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true });"
+		},
+		// Array literal as expected
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal(result, [1, 2, 3]);",
+			errors: [
+				{
+					messageId: "prefer-deep-equality",
+					data: { shallowMethodName: "equal", deepMethodName: "deepEqual" }
+				}
+			],
+			output: "import assert from 'node:assert/strict'; assert.deepEqual(result, [1, 2, 3]);"
+		},
+		// Empty object literal still flagged
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, {});",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, {});"
+		},
+		// Empty array literal still flagged
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, []);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, []);"
+		},
+		// Nested literals
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, { items: [1, 2, 3] });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { items: [1, 2, 3] });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal(result, [{ id: 1 }, { id: 2 }]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepEqual(result, [{ id: 1 }, { id: 2 }]);"
+		},
+		// Object literal as actual (also overlapping with no-constant-actual; we still flag)
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual({ ok: true }, result);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual({ ok: true }, result);"
+		},
+		// Both sides literal
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual({}, {});",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual({}, {});"
+		},
+		// Three-argument form preserves the trailing message
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, { ok: true }, 'oops');",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true }, 'oops');"
+		},
+
+		// `equal` paired with literals
+		{
+			code: "import assert from 'node:assert/strict'; assert.equal(result, { ok: true });",
+			errors: [
+				{
+					messageId: "prefer-deep-equality",
+					data: { shallowMethodName: "equal", deepMethodName: "deepEqual" }
+				}
+			],
+			output: "import assert from 'node:assert/strict'; assert.deepEqual(result, { ok: true });"
+		},
+
+		// Default import from `node:assert`
+		{
+			code: "import assert from 'node:assert'; assert.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert.deepStrictEqual(result, { ok: true });"
+		},
+		// Bare specifier without the node: protocol
+		{
+			code: "import assert from 'assert'; assert.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'assert'; assert.deepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'assert/strict'; assert.equal(result, [1, 2, 3]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'assert/strict'; assert.deepEqual(result, [1, 2, 3]);"
+		},
+
+		// Namespace import
+		{
+			code: "import * as assert from 'node:assert/strict'; assert.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import * as assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import * as assert from 'node:assert'; assert.equal(result, [1, 2, 3]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import * as assert from 'node:assert'; assert.deepEqual(result, [1, 2, 3]);"
+		},
+
+		// Named import (no autofix on identifier callees)
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+		{
+			code: "import { equal } from 'node:assert'; equal(result, [1, 2, 3]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+
+		// Renamed named import (still flagged, no autofix)
+		{
+			code: "import { strictEqual as eq } from 'node:assert/strict'; eq(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+
+		// Default + named combined: every offending call site is flagged
+		{
+			code:
+				"import assert, { strictEqual } from 'node:assert'; assert.strictEqual(a, { ok: true }); " +
+				"strictEqual(b, [1, 2]);",
+			errors: [{ messageId: "prefer-deep-equality" }, { messageId: "prefer-deep-equality" }],
+			output:
+				"import assert, { strictEqual } from 'node:assert'; assert.deepStrictEqual(a, { ok: true }); " +
+				"strictEqual(b, [1, 2]);"
+		},
+
+		// `strict` re-export via named import
+		{
+			code: "import { strict } from 'node:assert'; strict.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import { strict } from 'node:assert'; strict.deepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import { strict as s } from 'node:assert'; s.equal(result, [1, 2]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import { strict as s } from 'node:assert'; s.deepEqual(result, [1, 2]);"
+		},
+
+		// `strict` re-export via const destructuring (single-hop and renamed)
+		{
+			code: "import assert from 'node:assert'; const { strict } = assert; strict.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; const { strict } = assert; strict.deepStrictEqual(result, { ok: true });"
+		},
+		{
+			code: "import assert from 'node:assert'; const { strict: s } = assert; s.equal(result, [1, 2]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; const { strict: s } = assert; s.deepEqual(result, [1, 2]);"
+		},
+		// `strict` re-export through a multi-hop alias
+		{
+			code:
+				"import assert from 'node:assert'; const { strict } = assert; const s = strict; " +
+				"s.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output:
+				"import assert from 'node:assert'; const { strict } = assert; const s = strict; " +
+				"s.deepStrictEqual(result, { ok: true });"
+		},
+
+		// const namespace alias
+		{
+			code:
+				"import assert from 'node:assert/strict'; const alias = assert; " +
+				"alias.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output:
+				"import assert from 'node:assert/strict'; const alias = assert; " +
+				"alias.deepStrictEqual(result, { ok: true });"
+		},
+		// Multi-hop alias chain
+		{
+			code:
+				"import assert from 'node:assert/strict'; const a = assert; const b = a; " +
+				"b.strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output:
+				"import assert from 'node:assert/strict'; const a = assert; const b = a; " +
+				"b.deepStrictEqual(result, { ok: true });"
+		},
+
+		// Destructured method binding (not autofixed because the call site is an Identifier)
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual } = assert; strictEqual(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert/strict'; const { strictEqual: eq } = assert; eq(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+		{
+			code: "import assert from 'node:assert'; const { equal } = assert; equal(result, [1, 2, 3]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+
+		// Re-binding a named import (Identifier callee, no autofix)
+		{
+			code: "import { strictEqual } from 'node:assert/strict'; const eq = strictEqual; eq(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+		// Multi-hop alias of a named import
+		{
+			code:
+				"import { strictEqual } from 'node:assert/strict'; const eq1 = strictEqual; const eq2 = eq1; " +
+				"eq2(result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+
+		// Computed member access via a string literal
+		{
+			code: "import assert from 'node:assert'; assert['strictEqual'](result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert['deepStrictEqual'](result, { ok: true });"
+		},
+		// Computed member access via a constant template literal
+		{
+			code: "import assert from 'node:assert'; assert[`strictEqual`](result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert[`deepStrictEqual`](result, { ok: true });"
+		},
+		// Computed member access via a const-bound key (resolved through getPropertyName but not autofixable)
+		{
+			code: "import assert from 'node:assert'; const key = 'strictEqual'; assert[key](result, { ok: true });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: null
+		},
+
+		// Three-argument form with custom message preserved through the autofix
+		{
+			code: "import assert from 'node:assert'; assert.strictEqual(result, { ok: true }, 'mismatch');",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert.deepStrictEqual(result, { ok: true }, 'mismatch');"
+		},
+
+		// Both arguments are literals (also flagged by no-constant-actual; this rule still reports)
+		{
+			code: "import assert from 'node:assert'; assert.strictEqual([1, 2], [1, 2]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert.deepStrictEqual([1, 2], [1, 2]);"
+		},
+		{
+			code: "import assert from 'node:assert'; assert.equal({ a: 1 }, { a: 1 });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert'; assert.deepEqual({ a: 1 }, { a: 1 });"
+		},
+
+		// Calls inside various scopes are still resolved
+		{
+			code: "import assert from 'node:assert/strict'; function test() { assert.strictEqual(result, { ok: true }); }",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; function test() { assert.deepStrictEqual(result, { ok: true }); }"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; if (cond) { assert.strictEqual(result, [1, 2]); }",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; if (cond) { assert.deepStrictEqual(result, [1, 2]); }"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; class C { static { assert.strictEqual(result, {}); } }",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; class C { static { assert.deepStrictEqual(result, {}); } }"
+		},
+
+		// Object literal containing computed properties or shorthand still triggers
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, { [k]: 1 });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { [k]: 1 });"
+		},
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, { ok });",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, { ok });"
+		},
+
+		// Array literal with a spread element still triggers
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, [...items]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, [...items]);"
+		},
+		// Array literal with holes still triggers
+		{
+			code: "import assert from 'node:assert/strict'; assert.strictEqual(result, [, , 3]);",
+			errors: [{ messageId: "prefer-deep-equality" }],
+			output: "import assert from 'node:assert/strict'; assert.deepStrictEqual(result, [, , 3]);"
+		},
+
+		// Two flagged calls in the same file
+		{
+			code:
+				"import assert from 'node:assert/strict'; assert.strictEqual(a, { ok: true }); " +
+				"assert.equal(b, [1, 2]);",
+			errors: [{ messageId: "prefer-deep-equality" }, { messageId: "prefer-deep-equality" }],
+			output:
+				"import assert from 'node:assert/strict'; assert.deepStrictEqual(a, { ok: true }); " +
+				"assert.deepEqual(b, [1, 2]);"
+		}
+	]
+});


### PR DESCRIPTION
Flag assert.strictEqual / assert.equal calls whose first or second argument is an object or array literal — reference equality can never hold for a freshly allocated structure. Autofix rewrites the call to the deep variant (deepStrictEqual / deepEqual) and preserves a custom failure message in the third slot. Resolves through the same binding analysis as the other rules: default, named, namespace, renamed, computed, destructured, const-aliased, and the `strict` re-export.

Closes #549