### PR TITLE
Restrict duplicate CI runs on pull request branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,9 @@ name: CI
 
 on:
     push:
+        branches: [main]
     pull_request:
+        types: [opened, reopened, synchronize]
     merge_group:
 
 jobs:


### PR DESCRIPTION
The CI workflow was running the same test matrix twice for pull request branch updates: once for `push` and once for `pull_request`.

---

<img width="1625" height="643" alt="2026-05-15 13 57 27 github com 48331b3ae6aa" src="https://github.com/user-attachments/assets/505dbf3f-6844-497f-ba81-d144f0c52d18" />
